### PR TITLE
Fix Evaluator same address mapping clashes

### DIFF
--- a/Include/Rover/Evaluator.hpp
+++ b/Include/Rover/Evaluator.hpp
@@ -7,8 +7,7 @@
 #include <utility>
 #include <vector>
 
-namespace Rover {
-namespace Details {
+namespace Rover::Details {
 
   struct TypeErasingPtr {
     template<typename PtrFwd, std::enable_if_t<!std::is_same_v<std::decay_t<
@@ -22,7 +21,7 @@ namespace Details {
     const void* m_ptr;
     std::type_index m_type;
   };
-}}
+}
 
 namespace Rover {
 

--- a/Include/Rover/Evaluator.hpp
+++ b/Include/Rover/Evaluator.hpp
@@ -14,10 +14,10 @@ namespace Details {
 
   struct TypeErasingPtr {
     template<typename PtrFwd, std::enable_if_t<!std::is_same_v<std::decay_t<
-        PtrFwd>, TypeErasingPtr>>* = nullptr>
+      PtrFwd>, TypeErasingPtr>>* = nullptr>
     TypeErasingPtr(PtrFwd&& ptr)
-        : m_ptr(std::forward<PtrFwd>(ptr)),
-          m_type(typeid(*std::declval<std::decay_t<PtrFwd>>())) {}
+      : m_ptr(std::forward<PtrFwd>(ptr)),
+        m_type(typeid(*std::declval<std::decay_t<PtrFwd>>())) {}
 
     inline bool operator ==(const TypeErasingPtr& other) const {
       return m_ptr == other.m_ptr && m_type == other.m_type;
@@ -34,7 +34,7 @@ namespace std {
   struct hash<Rover::Details::TypeErasingPtr> {
     size_t operator()(const Rover::Details::TypeErasingPtr& ptr) const {
       return hash<const void*>()(ptr.m_ptr) + 0x9e3779b9 +
-          (ptr.m_type.hash_code() << 6) + (ptr.m_type.hash_code() >> 2);
+        (ptr.m_type.hash_code() << 6) + (ptr.m_type.hash_code() >> 2);
     }
   };
 }
@@ -73,19 +73,19 @@ namespace Rover {
         Evaluation(Generator& generator, std::unique_ptr<BaseEntry> entry);
       };
       std::unordered_map<Details::TypeErasingPtr, std::unique_ptr<BaseEntry>>
-          m_evaluations;
+        m_evaluations;
   };
 
   template<typename T>
   template<typename U>
   Evaluator::Entry<T>::Entry(U&& value)
-      : m_value(std::forward<U>(value)) {}
+    : m_value(std::forward<U>(value)) {}
 
   template<typename Generator>
   Evaluator::Evaluation::Evaluation(Generator& generator,
       std::unique_ptr<BaseEntry> entry)
-      : m_generator(&generator),
-        m_entry(std::move(entry)) {}
+    : m_generator(&generator),
+      m_entry(std::move(entry)) {}
 
   template<typename Generator>
   typename Generator::Type Evaluator::evaluate(Generator& generator) {

--- a/Include/Rover/Evaluator.hpp
+++ b/Include/Rover/Evaluator.hpp
@@ -8,14 +8,12 @@
 #include <vector>
 
 namespace Rover::Details {
-
   struct TypeErasingPtr {
-    template<typename PtrFwd, std::enable_if_t<!std::is_same_v<std::decay_t<
-      PtrFwd>, TypeErasingPtr>>* = nullptr>
-    TypeErasingPtr(PtrFwd&& ptr)
-      : m_ptr(std::forward<PtrFwd>(ptr)),
-        m_type(typeid(*std::declval<std::decay_t<PtrFwd>>())) {}
-    inline bool operator ==(const TypeErasingPtr& other) const {
+    template<typename Generator>
+    TypeErasingPtr(Generator* ptr)
+      : m_ptr(ptr),
+        m_type(typeid(Generator)) {}
+    bool operator ==(const TypeErasingPtr& other) const {
       return m_ptr == other.m_ptr && m_type == other.m_type;
     }
     const void* m_ptr;
@@ -75,7 +73,7 @@ namespace Rover {
     using Type = typename Generator::Type;
     auto type_erasing_ptr = Details::TypeErasingPtr(&generator);
     auto i = std::find_if(m_evaluations.begin(), m_evaluations.end(),
-      [&type_erasing_ptr](const auto& e) {
+      [&](const auto& e) {
         return type_erasing_ptr == e.m_generator;
       });
     if(i == m_evaluations.end()) {

--- a/Include/Rover/Evaluator.hpp
+++ b/Include/Rover/Evaluator.hpp
@@ -7,7 +7,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include "Pointer.hpp"
 
 namespace Rover {
 namespace Details {


### PR DESCRIPTION
Changes from fb1394 & fb1399 appear here too, should dissappear once the pull requests are merged.