### PR TITLE
Implement implicit conversions to Box

### DIFF
--- a/Python/Include/Box.hpp
+++ b/Python/Include/Box.hpp
@@ -58,7 +58,7 @@ namespace Rover {
         }))
       .def("generate", &Box<T>::generate);
     if constexpr(!std::is_same_v<T, pybind11::object>) {
-      implicitly_convertible<Box<T>, Box<pybind11::object>>();
+      pybind11::implicitly_convertible<Box<T>, Box<pybind11::object>>();
     }
   }
 }

--- a/Python/Include/Box.hpp
+++ b/Python/Include/Box.hpp
@@ -1,8 +1,66 @@
 #ifndef ROVER_PYTHON_BOX_HPP
 #define ROVER_PYTHON_BOX_HPP
+#include <optional>
 #include <string_view>
 #include <pybind11/pybind11.h>
+#include "Rover/Constant.hpp"
 #include "Rover/Box.hpp"
+
+namespace pybind11::detail {
+  template<>
+  struct type_caster<Rover::Box<object>> {
+    std::optional<Rover::Box<object>> value;
+
+    static PYBIND11_DESCR name() {
+      return type_descr(_("Box"));
+    }
+
+    template<typename T_,
+      std::enable_if_t<std::is_same_v<Rover::Box<object>, std::remove_cv_t<T_>>,
+      int> = 0>
+    static handle cast(T_* src, return_value_policy policy, handle parent) {
+      if(!src) {
+        return none().release();
+      }
+      if(policy == return_value_policy::take_ownership) {
+        auto h = cast(std::move(*src), policy, parent);
+        delete src;
+        return h;
+      } else {
+        return cast(*src, policy, parent);
+      }
+    }
+
+    operator Rover::Box<object>* () {
+      return &*value;
+    }
+
+    operator Rover::Box<object>& () {
+      return *value;
+    }
+
+    operator Rover::Box<object>&& () && {
+      return std::move(*value);
+    }
+
+    template <typename T_> using cast_op_type =
+      pybind11::detail::movable_cast_op_type<T_>;
+
+    bool load(handle src, bool) {
+      auto source = src.ptr();
+      if(!isinstance<Rover::Constant<object>>(src)) {
+        return false;
+      }
+      value.reset();
+      value.emplace(src.cast<Rover::Constant<object>>());
+      return true;
+    }
+
+    static handle cast(Rover::Box<object> src, return_value_policy, handle) {
+      return Py_None;
+    }
+  };
+}
 
 namespace Rover {
 

--- a/Python/Include/Box.hpp
+++ b/Python/Include/Box.hpp
@@ -10,20 +10,20 @@
 namespace Rover::Details {
   template<typename T>
   class PythonBox {
-  public:
-    using Type = T;
+    public:
+      using Type = T;
 
-    PythonBox(pybind11::object obj)
-      : m_obj(obj) {
-    }
+      PythonBox(pybind11::object obj)
+        : m_obj(obj) {
+      }
 
-    Type generate(Evaluator& e) {
-      auto wrapper = std::shared_ptr<Evaluator>(&e, [](auto ptr) {});
-      return m_obj.attr("generate")(std::move(wrapper)).cast<Type>();
-    }
+      Type generate(Evaluator& e) {
+        auto wrapper = std::shared_ptr<Evaluator>(&e, [](auto ptr) {});
+        return m_obj.attr("generate")(std::move(wrapper)).cast<Type>();
+      }
 
-  private:
-    pybind11::object m_obj;
+    private:
+      pybind11::object m_obj;
   };
 
   bool is_python_generator(pybind11::object arg);

--- a/Python/Include/Box.hpp
+++ b/Python/Include/Box.hpp
@@ -3,8 +3,8 @@
 #include <memory>
 #include <string_view>
 #include <pybind11/pybind11.h>
-#include "Rover/Constant.hpp"
 #include "Rover/Box.hpp"
+#include "Rover/Constant.hpp"
 #include "Rover/Evaluator.hpp"
 
 namespace Rover::Details {

--- a/Python/Include/Box.hpp
+++ b/Python/Include/Box.hpp
@@ -14,7 +14,7 @@ namespace Rover::Details {
       using Type = T;
 
       PythonBox(pybind11::object obj)
-        : m_obj(obj) {
+        : m_obj(std::move(obj)) {
       }
 
       Type generate(Evaluator& e) {
@@ -26,7 +26,7 @@ namespace Rover::Details {
       pybind11::object m_obj;
   };
 
-  bool is_python_generator(pybind11::object arg);
+  bool is_python_generator(const pybind11::object& arg);
 }
 
 namespace Rover {
@@ -49,7 +49,8 @@ namespace Rover {
       .def(init(
         [](pybind11::object arg) {
           if(Details::is_python_generator(arg)) {
-            return std::make_unique<Box<T>>(Details::PythonBox<T>(arg));
+            return std::make_unique<Box<T>>(Details::PythonBox<T>(std::move(
+              arg)));
           } else {
             return std::make_unique<Box<T>>(Constant(arg.cast<T>()));
           }

--- a/Python/Include/Box.hpp
+++ b/Python/Include/Box.hpp
@@ -6,10 +6,11 @@
 #include "Rover/Box.hpp"
 #include "Rover/Constant.hpp"
 #include "Rover/Evaluator.hpp"
+#include "Rover/Noncopyable.hpp"
 
 namespace Rover::Details {
   template<typename T>
-  class PythonBox {
+  class PythonBox : private Noncopyable {
     public:
       using Type = T;
 

--- a/Python/Include/Box.hpp
+++ b/Python/Include/Box.hpp
@@ -59,6 +59,7 @@ namespace Rover {
       .def("generate", &Box<T>::generate);
     if constexpr(!std::is_same_v<T, pybind11::object>) {
       pybind11::implicitly_convertible<Box<T>, Box<pybind11::object>>();
+      pybind11::implicitly_convertible<Box<pybind11::object>, Box<T>>();
     }
   }
 }

--- a/Python/Include/Constant.hpp
+++ b/Python/Include/Constant.hpp
@@ -2,6 +2,7 @@
 #define ROVER_PYTHON_CONSTANT_HPP
 #include <string_view>
 #include <pybind11/pybind11.h>
+#include "Rover/Box.hpp"
 #include "Rover/Constant.hpp"
 
 namespace Rover {

--- a/Python/Include/Constant.hpp
+++ b/Python/Include/Constant.hpp
@@ -23,9 +23,9 @@ namespace Rover {
     pybind11::class_<Constant<T>>(module, name.c_str())
       .def(pybind11::init<T>())
       .def("generate", &Constant<T>::generate);
-    implicitly_convertible<Constant<T>, Box<pybind11::object>>();
+    pybind11::implicitly_convertible<Constant<T>, Box<pybind11::object>>();
     if constexpr(!std::is_same_v<T, pybind11::object>) {
-      implicitly_convertible<Constant<T>, Constant<pybind11::object>>();
+      pybind11::implicitly_convertible<Constant<T>, Constant<pybind11::object>>();
     }
   }
 }

--- a/Python/Include/Constant.hpp
+++ b/Python/Include/Constant.hpp
@@ -25,9 +25,9 @@ namespace Rover {
       .def(pybind11::init<T>())
       .def("generate", &Constant<T>::generate);
     pybind11::implicitly_convertible<Constant<T>, Box<T>>();
-    pybind11::implicitly_convertible<Constant<T>, Box<pybind11::object>>();
     if constexpr(!std::is_same_v<T, pybind11::object>) {
       pybind11::implicitly_convertible<Constant<T>, Constant<pybind11::object>>();
+      pybind11::implicitly_convertible<Constant<T>, Box<pybind11::object>>();
     }
   }
 }

--- a/Python/Include/Constant.hpp
+++ b/Python/Include/Constant.hpp
@@ -24,6 +24,7 @@ namespace Rover {
     pybind11::class_<Constant<T>>(module, name.c_str())
       .def(pybind11::init<T>())
       .def("generate", &Constant<T>::generate);
+    pybind11::implicitly_convertible<Constant<T>, Box<T>>();
     pybind11::implicitly_convertible<Constant<T>, Box<pybind11::object>>();
     if constexpr(!std::is_same_v<T, pybind11::object>) {
       pybind11::implicitly_convertible<Constant<T>, Constant<pybind11::object>>();

--- a/Python/Include/Constant.hpp
+++ b/Python/Include/Constant.hpp
@@ -23,6 +23,10 @@ namespace Rover {
     pybind11::class_<Constant<T>>(module, name.c_str())
       .def(pybind11::init<T>())
       .def("generate", &Constant<T>::generate);
+    implicitly_convertible<Constant<T>, Box<pybind11::object>>();
+    if constexpr(!std::is_same_v<T, pybind11::object>) {
+      implicitly_convertible<Constant<T>, Constant<pybind11::object>>();
+    }
   }
 }
 

--- a/Python/Source/Box.cpp
+++ b/Python/Source/Box.cpp
@@ -3,7 +3,11 @@
 using namespace pybind11;
 using namespace Rover;
 
+bool Rover::Details::is_python_generator(pybind11::object arg) {
+  return pybind11::hasattr(arg, "generate") &&
+    PyCallable_Check(arg.attr("generate").ptr());
+}
+
 void Rover::export_box(module& module) {
-  pybind11::class_<Box<pybind11::object>>(module, "Box")
-    .def("generate", &Box<pybind11::object>::generate);
+  export_box<object>(module, "");
 }

--- a/Python/Source/Box.cpp
+++ b/Python/Source/Box.cpp
@@ -1,5 +1,4 @@
 #include "Box.hpp"
-#include "Rover/Constant.hpp"
 
 using namespace pybind11;
 using namespace Rover;

--- a/Python/Source/Box.cpp
+++ b/Python/Source/Box.cpp
@@ -3,7 +3,7 @@
 using namespace pybind11;
 using namespace Rover;
 
-bool Rover::Details::is_python_generator(pybind11::object arg) {
+bool Rover::Details::is_python_generator(const pybind11::object& arg) {
   return pybind11::hasattr(arg, "generate") &&
     PyCallable_Check(arg.attr("generate").ptr());
 }

--- a/Python/Source/Constant.cpp
+++ b/Python/Source/Constant.cpp
@@ -4,7 +4,5 @@ using namespace pybind11;
 using namespace Rover;
 
 void Rover::export_constant(module& module) {
-  pybind11::class_<Constant<pybind11::object>>(module, "Constant")
-    .def(pybind11::init<pybind11::object>())
-    .def("generate", &Constant<pybind11::object>::generate);
+  export_constant<object>(module, "");
 }

--- a/Python/Source/Evaluator.cpp
+++ b/Python/Source/Evaluator.cpp
@@ -1,6 +1,6 @@
 #include "Evaluator.hpp"
-#include "Rover/Box.hpp"
 #include "Rover/Evaluator.hpp"
+#include "Box.hpp"
 
 using namespace pybind11;
 using namespace Rover;
@@ -9,4 +9,8 @@ void Rover::export_evaluator(module& module) {
   pybind11::class_<Evaluator>(module, "Evaluator")
     .def(pybind11::init<>())
     .def("evaluate", &Evaluator::evaluate<Box<pybind11::object>>);
+  module.def("make_box",
+    [] () {
+      return Box(Constant(object(int_(123))));
+    });
 }

--- a/Python/Source/Evaluator.cpp
+++ b/Python/Source/Evaluator.cpp
@@ -1,16 +1,12 @@
 #include "Evaluator.hpp"
-#include "Rover/Evaluator.hpp"
 #include "Box.hpp"
+#include "Rover/Evaluator.hpp"
 
 using namespace pybind11;
 using namespace Rover;
 
 void Rover::export_evaluator(module& module) {
-  pybind11::class_<Evaluator>(module, "Evaluator")
-    .def(pybind11::init<>())
-    .def("evaluate", &Evaluator::evaluate<Box<pybind11::object>>);
-  module.def("make_box",
-    [] () {
-      return Box(Constant(object(int_(123))));
-    });
+  class_<Evaluator>(module, "Evaluator")
+    .def(init<>())
+    .def("evaluate", &Evaluator::evaluate<Box<object>>);
 }


### PR DESCRIPTION
One thing I could not handle is direct implicit conversion from Constant<T> to Box<T>. Pybind will not register such a conversion unless both types are instantiated, which leads to the chicken or the egg problem as both parties are templates. Constant<T> is implicitly convertible to Box<object> though, and so is it to Constant<object>; Box<T> is also convertible to Box<object>. Having said that, there is no impact on Python user code, unless I am missing something.