### PR TITLE
Implement TrialIterator and use it in ListTrial and TrialView

### DIFF
--- a/Include/Rover/ListTrial.hpp
+++ b/Include/Rover/ListTrial.hpp
@@ -1,6 +1,7 @@
 #ifndef ROVER_LIST_TRIAL_HPP
 #define ROVER_LIST_TRIAL_HPP
 #include <vector>
+#include "Rover/TrialIterator.hpp"
 
 namespace Rover {
 
@@ -16,7 +17,7 @@ namespace Rover {
       using Sample = S;
 
       //! The type of the constant iterator.
-      using ConstIterator = typename std::vector<Sample>::const_iterator;
+      using Iterator = typename TrialIterator<ListTrial>;
   
       //! Increases the capacity of the underlying array.
       void reserve(std::size_t capacity);
@@ -32,10 +33,10 @@ namespace Rover {
       void insert(Begin b, End e);
   
       //! Returns a constant iterator to the first sample
-      ConstIterator begin() const;
+      Iterator begin() const;
 
       //! Returns a constant iterator to the past-the-end sample
-      ConstIterator end() const;
+      Iterator end() const;
 
       //! Number of samples in this trial.
       std::size_t size() const;
@@ -68,17 +69,17 @@ namespace Rover {
   template<typename S>
   template<typename Begin, typename End>
   void ListTrial<S>::insert(Begin begin, End end) {
-    m_samples.insert(m_samples.end(), begin, end);
+    std::copy(begin, end, std::back_inserter(m_samples));
   }
 
   template<typename S>
-  typename ListTrial<S>::ConstIterator ListTrial<S>::begin() const {
-    return m_samples.begin();
+  typename ListTrial<S>::Iterator ListTrial<S>::begin() const {
+    return Iterator(*this, 0);
   }
 
   template<typename S>
-  typename ListTrial<S>::ConstIterator ListTrial<S>::end() const {
-    return m_samples.end();
+  typename ListTrial<S>::Iterator ListTrial<S>::end() const {
+    return Iterator(*this, size());
   }
 
   template<typename S>

--- a/Include/Rover/ListTrial.hpp
+++ b/Include/Rover/ListTrial.hpp
@@ -17,7 +17,7 @@ namespace Rover {
       using Sample = S;
 
       //! The type of the constant iterator.
-      using Iterator = typename TrialIterator<ListTrial>;
+      using Iterator = TrialIterator<ListTrial>;
   
       //! Increases the capacity of the underlying array.
       void reserve(std::size_t capacity);

--- a/Include/Rover/TrialIterator.hpp
+++ b/Include/Rover/TrialIterator.hpp
@@ -10,16 +10,15 @@ namespace Rover {
   template<typename, typename = void>
   class TrialIterator;
 
-  //! Type traits to check whether a Trial returns Samples by copy.
-  template<typename T>
-  inline constexpr bool returns_sample_by_copy_v = std::is_same_v<decltype(
-    std::declval<T>()[std::declval<std::size_t>()]), typename T::Sample>;
-
   //! Type traits to check whether a Trial returns Samples by reference.
   template<typename T>
-  inline constexpr bool returns_sample_by_reference_v = std::is_same_v<
-    decltype(std::declval<T>()[std::declval<std::size_t>()]), typename const
-    T::Sample&>;
+  inline constexpr bool returns_sample_by_reference_v = std::is_reference_v<
+    decltype(std::declval<T>()[std::declval<std::size_t>()])>;
+
+  //! Type traits to check whether a Trial returns Samples by copy.
+  template<typename T>
+  inline constexpr bool returns_sample_by_copy_v =
+    !returns_sample_by_reference_v<T>;
 
   //! Iterator over a Trial that returns Samples by copy.
   /*

--- a/Include/Rover/TrialIterator.hpp
+++ b/Include/Rover/TrialIterator.hpp
@@ -1,0 +1,520 @@
+#ifndef ROVER_TRIAL_ITERATOR_HPP
+#define ROVER_TRIAL_ITERATOR_HPP
+#include <iterator>
+#include <optional>
+#include <type_traits>
+
+namespace Rover {
+
+  //! Iterator over a Trial.
+  template<typename, typename = void>
+  class TrialIterator;
+
+  //! Type traits to check whether a Trial returns Samples by copy.
+  template<typename T>
+  inline constexpr bool returns_sample_by_copy_v = std::is_same_v<decltype(
+    std::declval<T>()[std::declval<std::size_t>()]), typename T::Sample>;
+
+  //! Type traits to check whether a Trial returns Samples by reference.
+  template<typename T>
+  inline constexpr bool returns_sample_by_reference_v = std::is_same_v<
+    decltype(std::declval<T>()[std::declval<std::size_t>()]), typename const
+    T::Sample&>;
+
+  //! Iterator over a Trial that returns Samples by copy.
+  /*
+    \tparam T The type of the Trial.
+    \details Relies on the operator []'s return type to identify the
+             return-by-copy. Returned references and pointers are only valid
+             as long as the iterator is alive and another de-referencing
+             operation is executed.
+  */
+  template<typename T>
+  class TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<T>>> {
+    public:
+
+      using iterator_category = std::input_iterator_tag;
+
+      //! The type of the trial.
+      using Trial = T;
+
+      //! The type of the samples.
+      using Sample = typename Trial::Sample;
+
+      //! Iterator category for compliance with STL algorithms.
+      using iterator_category = std::input_iterator_tag;
+
+      //! Iterator value type for compliance with STL algorithms.
+      using value_type = Sample;
+
+      //! Iterator difference type for compliance with STL algorithms.
+      using difference_type = std::ptrdiff_t;
+
+      //! Iterator pointer type for compliance with STL algorithms.
+      using pointer = const Sample*;
+
+      //! Iterator reference type for compliance with STL algorithms.
+      using reference = const Sample&;
+
+      //! Increments the iterator.
+      TrialIterator& operator ++();
+
+      //! Increments the iterator.
+      TrialIterator operator ++(int);
+
+      //! Decrements the iterator.
+      TrialIterator& operator --();
+
+      //! Decrements the iterator.
+      TrialIterator operator --(int);
+
+      //! Advances the iterator.
+      TrialIterator& operator +=(std::ptrdiff_t offset);
+
+      //! Moves the iterator back.
+      TrialIterator& operator -=(std::ptrdiff_t offset);
+
+      //! Returns an iterator that is the result of advancing this.
+      TrialIterator operator +(std::ptrdiff_t offset) const;
+
+      //! Returns an iterator that is the result of moving this back.
+      TrialIterator operator -(std::ptrdiff_t offset) const;
+
+      //! Returns the offset between two iterators.
+      std::ptrdiff_t operator -(const TrialIterator& other) const;
+
+      //! Checks whether two iterators point to the same Sample.
+      bool operator ==(const TrialIterator& other) const;
+
+      //! Checks whether two iterators do not point to the same Sample.
+      bool operator !=(const TrialIterator& other) const;
+
+      //! Checks whether the Sample pointed to by the first iterator is to
+      //! the left of that pointed to by the second iterator.
+      bool operator <(const TrialIterator& other) const;
+
+      //! Checks whether the Sample pointed to by the first iterator is not
+      //! to the right of that pointed to by the second iterator.
+      bool operator <=(const TrialIterator& other) const;
+
+      //! Checks whether the Sample pointed to by the first iterator is to
+      //! the right of that pointed to by the second iterator.
+      bool operator >(const TrialIterator& other) const;
+
+      //! Checks whether the Sample pointed to by the first iterator is not
+      //! to the left of that pointed to by the second iterator.
+      bool operator >=(const TrialIterator& other) const;
+
+      //! Returns a reference to the Sample the iterator points to.
+      /*
+        \details The reference is valid as long as the iterator is alive, or
+                 until another de-referencing operation is executed.
+      */
+      const Sample& operator *();
+
+      //! Returns a pointer to the Sample the iterator points to.
+      /*
+        \details The pointer is valid as long as the iterator is alive, or
+                 until another de-referencing operation is executed.
+      */
+      const Sample* operator ->();
+
+      //! Returns a reference to the Sample the iterator would point to
+      //! if it was advanced by the offset.
+      /*
+        \details The reference is valid as long as the iterator is alive, or
+                 until another de-referencing operation is executed.
+      */
+      const Sample& operator [](std::ptrdiff_t offset);
+
+    private:
+      friend Trial;
+
+      const Trial* m_trial;
+      std::size_t m_offset;
+      std::optional<Sample> m_sample;
+
+      TrialIterator(const Trial& trial, std::size_t offset);
+  };
+
+  //! Iterator over a Trial that returns Samples by reference.
+  /*
+    \tparam T The type of the Trial.
+    \details Relies on the operator []'s return type to identify the
+             return-by-reference.
+  */
+  template<typename T>
+  class TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<T>>> {
+    public:
+
+      //! The type of the trial.
+      using Trial = T;
+
+      //! The type of the samples.
+      using Sample = typename Trial::Sample;
+
+      //! Iterator category for compliance with STL algorithms.
+      using iterator_category = std::random_access_iterator_tag;
+
+      //! Iterator value type for compliance with STL algorithms.
+      using value_type = Sample;
+
+      //! Iterator difference type for compliance with STL algorithms.
+      using difference_type = std::ptrdiff_t;
+
+      //! Iterator pointer type for compliance with STL algorithms.
+      using pointer = const Sample*;
+
+      //! Iterator reference type for compliance with STL algorithms.
+      using reference = const Sample&;
+
+      //! Increments the iterator.
+      TrialIterator& operator ++();
+
+      //! Increments the iterator.
+      TrialIterator operator ++(int);
+
+      //! Decrements the iterator.
+      TrialIterator& operator --();
+
+      //! Decrements the iterator.
+      TrialIterator operator --(int);
+
+      //! Advances the iterator.
+      TrialIterator& operator +=(std::ptrdiff_t offset);
+
+      //! Moves the iterator back.
+      TrialIterator& operator -=(std::ptrdiff_t offset);
+
+      //! Returns an iterator that is the result of advancing this.
+      TrialIterator operator +(std::ptrdiff_t offset) const;
+
+      //! Returns an iterator that is the result of moving this back.
+      TrialIterator operator -(std::ptrdiff_t offset) const;
+
+      //! Returns the offset between two iterators.
+      std::ptrdiff_t operator -(TrialIterator other) const;
+
+      //! Checks whether two iterators point to the same Sample.
+      bool operator ==(TrialIterator other) const;
+
+      //! Checks whether two iterators do not point to the same Sample.
+      bool operator !=(TrialIterator other) const;
+
+      //! Checks whether the Sample pointed to by the first iterator is to
+      //! the left of that pointed to by the second iterator.
+      bool operator <(TrialIterator other) const;
+
+      //! Checks whether the Sample pointed to by the first iterator is not
+      //! to the right of that pointed to by the second iterator.
+      bool operator <=(TrialIterator other) const;
+
+      //! Checks whether the Sample pointed to by the first iterator is to
+      //! the right of that pointed to by the second iterator.
+      bool operator >(TrialIterator other) const;
+
+      //! Checks whether the Sample pointed to by the first iterator is not
+      //! to the left of that pointed to by the second iterator.
+      bool operator >=(TrialIterator other) const;
+
+      //! Returns a reference to the Sample the iterator points to.
+      const Sample& operator *() const;
+
+      //! Returns a pointer to the Sample the iterator points to.
+      const Sample* operator ->() const;
+
+      //! Returns a reference to the Sample the iterator would point to
+      //! if it was advanced by the offset.
+      const Sample& operator [](std::ptrdiff_t offset) const;
+
+    private:
+      friend Trial;
+
+      const Trial* m_trial;
+      std::size_t m_offset;
+
+      TrialIterator(const Trial& trial, std::size_t offset);
+  };
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<T>>>&
+      TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator ++() {
+    ++m_offset;
+    return *this;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<T>>>
+      TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator ++(int) {
+    auto copy = *this;
+    ++m_offset;
+    return copy;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<T>>>&
+      TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator --() {
+    --m_offset;
+    return *this;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<T>>>
+      TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator --(int) {
+    auto copy = *this;
+    --m_offset;
+    return copy;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<T>>>&
+      TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator +=(std::ptrdiff_t offset) {
+    m_offset += offset;
+    return *this;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<T>>>&
+      TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator -=(std::ptrdiff_t offset) {
+    m_offset -= offset;
+    return *this;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<T>>>
+      TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator +(std::ptrdiff_t offset) const {
+    auto result = *this;
+    result += offset;
+    return result;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<T>>>
+      TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator -(std::ptrdiff_t offset) const {
+    auto result = *this;
+    result -= offset;
+    return result;
+  }
+
+  template<typename T>
+  std::ptrdiff_t TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator -(const TrialIterator& other) const {
+    return m_offset - other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator ==(const TrialIterator& other) const {
+    return m_offset == other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator !=(const TrialIterator& other) const {
+    return m_offset != other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator <(const TrialIterator& other) const {
+    return m_offset < other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator <=(const TrialIterator& other) const {
+    return m_offset <= other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator >(const TrialIterator& other) const {
+    return m_offset > other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator >=(const TrialIterator& other) const {
+    return m_offset >= other.m_offset;
+  }
+
+  template<typename T>
+  typename const TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::Sample& TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator *() {
+    m_sample = (*m_trial)[m_offset];
+    return m_sample;
+  }
+
+  template<typename T>
+  typename const TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::Sample* TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator ->() {
+    m_sample = (*m_trial)[m_offset];
+    return std::addressof(m_sample);
+  }
+
+  template<typename T>
+  typename const TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::Sample& TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::operator [](std::ptrdiff_t offset) {
+    m_sample = (*m_trial)[m_offset + offset];
+    return m_sample;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
+      T>>>::TrialIterator(const Trial& trial, std::size_t offset)
+    : m_trial(&trial),
+      m_offset(offset) {}
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<T>>>&
+      TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator ++() {
+    ++m_offset;
+    return *this;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<T>>>
+      TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator ++(int) {
+    auto copy = *this;
+    ++m_offset;
+    return copy;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<T>>>&
+      TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator --() {
+    --m_offset;
+    return *this;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<T>>>
+      TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator --(int) {
+    auto copy = *this;
+    --m_offset;
+    return copy;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<T>>>&
+      TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator +=(std::ptrdiff_t offset) {
+    m_offset += offset;
+    return *this;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<T>>>&
+      TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator -=(std::ptrdiff_t offset) {
+    m_offset -= offset;
+    return *this;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<T>>>
+      TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator +(std::ptrdiff_t offset) const {
+    auto result = *this;
+    result += offset;
+    return result;
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<T>>>
+      TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator -(std::ptrdiff_t offset) const {
+    auto result = *this;
+    result -= offset;
+    return result;
+  }
+
+  template<typename T>
+  std::ptrdiff_t TrialIterator<T, std::enable_if_t<
+      returns_sample_by_reference_v<T>>>::operator -(TrialIterator other)
+      const {
+    return m_offset - other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator ==(TrialIterator other) const {
+    return m_offset == other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator !=(TrialIterator other) const {
+    return m_offset != other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator <(TrialIterator other) const {
+    return m_offset < other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator <=(TrialIterator other) const {
+    return m_offset <= other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator >(TrialIterator other) const {
+    return m_offset > other.m_offset;
+  }
+
+  template<typename T>
+  bool TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::operator >=(TrialIterator other) const {
+    return m_offset >= other.m_offset;
+  }
+
+  template<typename T>
+  typename const TrialIterator<T, std::enable_if_t<
+      returns_sample_by_reference_v<T>>>::Sample& TrialIterator<T,
+      std::enable_if_t<returns_sample_by_reference_v<T>>>::operator *() const {
+    return (*m_trial)[m_offset];
+  }
+
+  template<typename T>
+  typename const TrialIterator<T, std::enable_if_t<
+      returns_sample_by_reference_v<T>>>::Sample* TrialIterator<T,
+      std::enable_if_t<returns_sample_by_reference_v<T>>>::operator ->()
+      const {
+    return std::addressof((*m_trial)[m_offset]);
+  }
+
+  template<typename T>
+  typename const TrialIterator<T, std::enable_if_t<
+      returns_sample_by_reference_v<T>>>::Sample& TrialIterator<T,
+      std::enable_if_t<returns_sample_by_reference_v<T>>>::operator [](
+      std::ptrdiff_t offset) const {
+    return (*m_trial)[m_offset + offset];
+  }
+
+  template<typename T>
+  TrialIterator<T, std::enable_if_t<returns_sample_by_reference_v<
+      T>>>::TrialIterator(const Trial& trial, std::size_t offset)
+    : m_trial(&trial),
+      m_offset(offset) {}
+}
+
+#endif

--- a/Include/Rover/TrialIterator.hpp
+++ b/Include/Rover/TrialIterator.hpp
@@ -33,8 +33,6 @@ namespace Rover {
   class TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<T>>> {
     public:
 
-      using iterator_category = std::input_iterator_tag;
-
       //! The type of the trial.
       using Trial = T;
 
@@ -350,16 +348,15 @@ namespace Rover {
   typename const TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
       T>>>::Sample& TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
       T>>>::operator *() {
-    m_sample = (*m_trial)[m_offset];
-    return m_sample;
+    return (*this)[0];
   }
 
   template<typename T>
   typename const TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
       T>>>::Sample* TrialIterator<T, std::enable_if_t<returns_sample_by_copy_v<
       T>>>::operator ->() {
-    m_sample = (*m_trial)[m_offset];
-    return std::addressof(m_sample);
+    m_sample.emplace((*m_trial)[m_offset]);
+    return std::addressof((*this)[0]);
   }
 
   template<typename T>

--- a/Include/Rover/TrialView.hpp
+++ b/Include/Rover/TrialView.hpp
@@ -1,6 +1,7 @@
 #ifndef ROVER_TRIAL_VIEW_HPP
 #define ROVER_TRIAL_VIEW_HPP
 #include <functional>
+#include "TrialIterator.hpp"
 
 namespace Rover {
 
@@ -15,92 +16,18 @@ namespace Rover {
       //! The type of the samples stored in the Trial.
       using Sample = S;
 
-    private:
-      using GetPtr = std::function<const Sample* (std::size_t)>;
-
-    public:
-
-      //! Random access constant iterator.
-      class ConstIterator {
-        public:
-
-          //! Increments the iterator.
-          ConstIterator& operator ++();
-
-          //! Increments the iterator.
-          ConstIterator operator ++(int);
-
-          //! Decrements the iterator.
-          ConstIterator& operator --();
-
-          //! Decrements the iterator.
-          ConstIterator operator --(int);
-
-          //! Advances the iterator.
-          ConstIterator& operator +=(std::ptrdiff_t offset);
-
-          //! Moves the iterator back.
-          ConstIterator& operator -=(std::ptrdiff_t offset);
-
-          //! Returns an iterator that is the result of advancing this.
-          ConstIterator operator +(std::ptrdiff_t offset) const;
-
-          //! Returns an iterator that is the result of moving this back.
-          ConstIterator operator -(std::ptrdiff_t offset) const;
-
-          //! Returns the offset between two iterators.
-          std::ptrdiff_t operator -(ConstIterator other) const;
-
-          //! Checks whether two iterators point to the same Sample.
-          bool operator ==(ConstIterator other) const;
-
-          //! Checks whether two iterators do not point to the same Sample.
-          bool operator !=(ConstIterator other) const;
-
-          //! Checks whether the Sample pointed to by the first iterator is to
-          //! the left of that pointed to by the second iterator.
-          bool operator <(ConstIterator other) const;
-
-          //! Checks whether the Sample pointed to by the first iterator is not
-          //! to the right of that pointed to by the second iterator.
-          bool operator <=(ConstIterator other) const;
-
-          //! Checks whether the Sample pointed to by the first iterator is to
-          //! the right of that pointed to by the second iterator.
-          bool operator >(ConstIterator other) const;
-
-          //! Checks whether the Sample pointed to by the first iterator is not
-          //! to the left of that pointed to by the second iterator.
-          bool operator >=(ConstIterator other) const;
-
-          //! Returns a reference to the Sample the iterator points to.
-          const Sample& operator *() const;
-
-          //! Returns a pointer to the Sample the iterator points to.
-          const Sample* operator ->() const;
-
-          //! Returns a reference to the Sample the iterator would point to
-          //! if it was advanced by the offset.
-          const Sample& operator [](std::ptrdiff_t offset) const;
-
-        private:
-          friend class TrialView<S>;
-
-          const GetPtr* m_get_ptr;
-          std::size_t m_offset;
-
-          ConstIterator(const GetPtr& get_ptr, std::size_t offset);
-      };
+      //! The type of the iterator.
+      using Iterator = TrialIterator<TrialView>;
 
       //! Creates a TrialView for a trial.
       template<typename Trial>
       TrialView(const Trial& t);
 
       //! Returns an iterator to the beginning of the trial.
-      ConstIterator begin() const;
+      Iterator begin() const;
 
       //! Returns an iterator to the end of the trial.
-      ConstIterator end() const;
+      Iterator end() const;
 
       //! Returns the size of the trial.
       std::size_t size() const;
@@ -109,132 +36,14 @@ namespace Rover {
       const Sample& operator [](std::size_t index) const;
 
     private:
+      using GetPtr = std::function<const Sample* (std::size_t)>;
+
       std::size_t m_size;
       GetPtr m_get_ptr;
   };
 
   template<typename Trial>
   TrialView(const Trial&) -> TrialView<typename Trial::Sample>;
-
-  template<typename S>
-  TrialView<S>::ConstIterator::ConstIterator(const GetPtr& get_ptr,
-      std::size_t offset)
-    : m_get_ptr(&get_ptr),
-      m_offset(offset) {}
-
-  template<typename S>
-  typename TrialView<S>::ConstIterator&
-      TrialView<S>::ConstIterator::operator ++() {
-    ++m_offset;
-    return *this;
-  }
-
-  template<typename S>
-  typename TrialView<S>::ConstIterator
-      TrialView<S>::ConstIterator::operator ++(int) {
-    auto copy = *this;
-    ++m_offset;
-    return copy;
-  }
-
-  template<typename S>
-  typename TrialView<S>::ConstIterator&
-      TrialView<S>::ConstIterator::operator --() {
-    --m_offset;
-    return *this;
-  }
-
-  template<typename S>
-  typename TrialView<S>::ConstIterator
-      TrialView<S>::ConstIterator::operator --(int) {
-    auto copy = *this;
-    --m_offset;
-    return copy;
-  }
-
-  template<typename S>
-  typename TrialView<S>::ConstIterator&
-      TrialView<S>::ConstIterator::operator +=(std::ptrdiff_t offset) {
-    m_offset += offset;
-    return *this;
-  }
-
-  template<typename S>
-  typename TrialView<S>::ConstIterator&
-      TrialView<S>::ConstIterator::operator -=(std::ptrdiff_t offset) {
-    m_offset -= offset;
-    return *this;
-  }
-
-  template<typename S>
-  typename TrialView<S>::ConstIterator
-      TrialView<S>::ConstIterator::operator +(std::ptrdiff_t offset) const {
-    auto result = *this;
-    result += offset;
-    return result;
-  }
-
-  template<typename S>
-  typename TrialView<S>::ConstIterator
-      TrialView<S>::ConstIterator::operator -(std::ptrdiff_t offset) const {
-    auto result = *this;
-    result -= offset;
-    return result;
-  }
-
-  template<typename S>
-  std::ptrdiff_t TrialView<S>::ConstIterator::operator -(
-      ConstIterator other) const {
-    return m_offset - other.m_offset;
-  }
-
-  template<typename S>
-  bool TrialView<S>::ConstIterator::operator ==(ConstIterator other) const {
-    return m_offset == other.m_offset;
-  }
-
-  template<typename S>
-  bool TrialView<S>::ConstIterator::operator !=(ConstIterator other) const {
-    return m_offset != other.m_offset;
-  }
-
-  template<typename S>
-  bool TrialView<S>::ConstIterator::operator <(ConstIterator other) const {
-    return m_offset < other.m_offset;
-  }
-
-  template<typename S>
-  bool TrialView<S>::ConstIterator::operator <=(ConstIterator other) const {
-    return m_offset <= other.m_offset;
-  }
-
-  template<typename S>
-  bool TrialView<S>::ConstIterator::operator >(ConstIterator other) const {
-    return m_offset > other.m_offset;
-  }
-
-  template<typename S>
-  bool TrialView<S>::ConstIterator::operator >=(ConstIterator other) const {
-    return m_offset >= other.m_offset;
-  }
-
-  template<typename S>
-  typename const TrialView<S>::Sample&
-      TrialView<S>::ConstIterator::operator *() const {
-    return *(*m_get_ptr)(m_offset);
-  }
-
-  template<typename S>
-  typename const TrialView<S>::Sample*
-      TrialView<S>::ConstIterator::operator ->() const {
-    return (*m_get_ptr)(m_offset);
-  }
-
-  template<typename S>
-  typename const TrialView<S>::Sample&
-      TrialView<S>::ConstIterator::operator [](std::ptrdiff_t offset) const {
-    return *(*m_get_ptr)(m_offset + offset);
-  }
 
   template<typename T>
   template<typename Trial>
@@ -245,13 +54,13 @@ namespace Rover {
       }) {}
 
   template<typename T>
-  typename TrialView<T>::ConstIterator TrialView<T>::begin() const {
-    return ConstIterator(m_get_ptr, 0);
+  typename TrialView<T>::Iterator TrialView<T>::begin() const {
+    return Iterator(*this, 0);
   }
 
   template<typename T>
-  typename TrialView<T>::ConstIterator TrialView<T>::end() const {
-    return ConstIterator(m_get_ptr, m_size);
+  typename TrialView<T>::Iterator TrialView<T>::end() const {
+    return Iterator(*this, m_size);
   }
 
   template<typename T>
@@ -262,7 +71,7 @@ namespace Rover {
   template<typename T>
   typename const TrialView<T>::Sample& TrialView<T>::operator [](std::size_t
       index) const {
-    return begin()[index];
+    return *m_get_ptr(index);
   }
 }
 


### PR DESCRIPTION
I could use a common base for some of the iterator operations, but most are incompatible (by-copy versions takes iterators by const reference due to them holding memory for samples) so it was just getting more complicated.
I did not include any changes already available in fb1447 to minimize merge conflicts later on.