### PR TITLE
Implement PythonScalar

### DIFF
--- a/Python/Include/Arithmetics.hpp
+++ b/Python/Include/Arithmetics.hpp
@@ -14,6 +14,35 @@ namespace Rover::Details {
   inline constexpr bool contain_objects_v = contain_objects<Args...>::value;
 
   const pybind11::module& import_operator();
+
+  template<typename T1, typename T2>
+  struct OperatorApplicator;
+
+  template<typename T>
+  struct OperatorApplicator<T, pybind11::object> {
+    pybind11::object operator()(const char* operator_name, const T& lhs,
+        const pybind11::object& rhs) {
+      auto lhs_object = pybind11::cast(lhs);
+      return import_operator().attr(operator_name)(lhs_object, rhs);
+    }
+  };
+
+  template<typename T>
+  struct OperatorApplicator<pybind11::object, T> {
+    pybind11::object operator()(const char* operator_name, const
+        pybind11::object& lhs, const T& rhs) {
+      auto rhs_object = pybind11::cast(rhs);
+      return import_operator().attr(operator_name)(lhs, rhs_object);
+    }
+  };
+
+  template<>
+  struct OperatorApplicator<pybind11::object, pybind11::object> {
+    pybind11::object operator()(const char* operator_name, const
+        pybind11::object& lhs, const pybind11::object& rhs) {
+      return import_operator().attr(operator_name)(lhs, rhs);
+    }
+  };
 }
 
 namespace pybind11 {
@@ -23,78 +52,74 @@ namespace pybind11 {
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, bool> 
       operator <(const T1& lhs, const T2& rhs) {
-    return Rover::Details::import_operator().attr("__lt__")(lhs,
+    return Rover::Details::OperatorApplicator<T1, T2>()("__lt__", lhs,
       rhs).template cast<bool>();
   }
 
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, bool>
       operator <=(const T1& lhs, const T2& rhs) {
-    return Rover::Details::import_operator().attr("__le__")(lhs,
+    return Rover::Details::OperatorApplicator<T1, T2>()("__le__", lhs,
       rhs).template cast<bool>();
   }
 
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, bool>
       operator >(const T1& lhs, const T2& rhs) {
-    return Rover::Details::import_operator().attr("__gt__")(lhs,
+    return Rover::Details::OperatorApplicator<T1, T2>()("__gt__", lhs,
       rhs).template cast<bool>();
   }
 
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, bool>
       operator >=(const T1& lhs, const T2& rhs) {
-    return Rover::Details::import_operator().attr("__ge__")(lhs,
+    return Rover::Details::OperatorApplicator<T1, T2>()("__ge__", lhs,
       rhs).template cast<bool>();
   }
 
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, bool>
       operator ==(const T1& lhs, const T2& rhs) {
-    return Rover::Details::import_operator().attr("__eq__")(lhs,
+    return Rover::Details::OperatorApplicator<T1, T2>()("__eq__", lhs,
       rhs).template cast<bool>();
   }
 
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, bool>
       operator !=(const T1& lhs, const T2& rhs) {
-    return Rover::Details::import_operator().attr("__ne__")(lhs,
+    return Rover::Details::OperatorApplicator<T1, T2>()("__ne__", lhs,
       rhs).template cast<bool>();
   }
   
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, object>
       operator +(const T1& lhs, const T2& rhs) {
-    return Rover::Details::import_operator().attr("__add__")(lhs,
-      rhs);
+    return Rover::Details::OperatorApplicator<T1, T2>()("__add__", lhs, rhs);
   }
   
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, object>
       operator -(const T1& lhs, const T2& rhs) {
-    return Rover::Details::import_operator().attr("__sub__")(lhs,
-      rhs);
+    return Rover::Details::OperatorApplicator<T1, T2>()("__sub__", lhs, rhs);
   }
 
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, object>
       operator *(const T1& lhs, const T2& rhs) {
-    return Rover::Details::import_operator().attr("__mul__")(lhs,
-      rhs);
+    return Rover::Details::OperatorApplicator<T1, T2>()("__mul__", lhs, rhs);
   }
 
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, object>
       operator /(const T1& lhs, const T2& rhs) {
-    return Rover::Details::import_operator().attr("__floordiv__")(lhs,
+    return Rover::Details::OperatorApplicator<T1, T2>()("__floordiv__", lhs,
       rhs);
   }
 
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, object>
       operator %(const T1& lhs, const T2& rhs) {
-    return Rover::Details::import_operator().attr("__mod__")(lhs,
-      rhs);
+    return Rover::Details::OperatorApplicator<T1, T2>()("__mod__", lhs, rhs);
   }
 }
 

--- a/Python/Include/Arithmetics.hpp
+++ b/Python/Include/Arithmetics.hpp
@@ -15,6 +15,9 @@ namespace Rover::Details {
 
   const pybind11::module& import_operator();
 
+  pybind11::object apply_operator(const char* operator_name, const
+    pybind11::object& lhs, const pybind11::object& rhs);
+
   template<typename T1, typename T2>
   struct OperatorApplicator;
 
@@ -23,7 +26,7 @@ namespace Rover::Details {
     pybind11::object operator()(const char* operator_name, const T& lhs,
         const pybind11::object& rhs) {
       auto lhs_object = pybind11::cast(lhs);
-      return import_operator().attr(operator_name)(lhs_object, rhs);
+      return apply_operator(operator_name, lhs_object, rhs);
     }
   };
 
@@ -32,7 +35,7 @@ namespace Rover::Details {
     pybind11::object operator()(const char* operator_name, const
         pybind11::object& lhs, const T& rhs) {
       auto rhs_object = pybind11::cast(rhs);
-      return import_operator().attr(operator_name)(lhs, rhs_object);
+      return apply_operator(operator_name, lhs, rhs_object);
     }
   };
 
@@ -40,7 +43,7 @@ namespace Rover::Details {
   struct OperatorApplicator<pybind11::object, pybind11::object> {
     pybind11::object operator()(const char* operator_name, const
         pybind11::object& lhs, const pybind11::object& rhs) {
-      return import_operator().attr(operator_name)(lhs, rhs);
+      return apply_operator(operator_name, lhs, rhs);
     }
   };
 }

--- a/Python/Include/Arithmetics.hpp
+++ b/Python/Include/Arithmetics.hpp
@@ -115,7 +115,7 @@ namespace pybind11 {
   template<typename T1, typename T2>
   std::enable_if_t<Rover::Details::contain_objects_v<T1, T2>, object>
       operator /(const T1& lhs, const T2& rhs) {
-    return Rover::Details::OperatorApplicator<T1, T2>()("__floordiv__", lhs,
+    return Rover::Details::OperatorApplicator<T1, T2>()("__truediv__", lhs,
       rhs);
   }
 

--- a/Python/Include/Scalar.hpp
+++ b/Python/Include/Scalar.hpp
@@ -20,9 +20,6 @@ namespace Rover {
   class PythonScalarPointer {
     public:
 
-      //! Constructs the object using a raw PythonScalar<T> pointer.
-      PythonScalarPointer(PythonScalar<T>* ptr);
-
       //! Converts the pointer to PythonScalar<T>*.
       operator PythonScalar<T>*() const;
 
@@ -30,7 +27,11 @@ namespace Rover {
       operator T*() const;
 
     private:
+      friend PythonScalar<T>;
+
       PythonScalar<T>* m_ptr;
+
+      explicit PythonScalarPointer(PythonScalar<T>* ptr);
   };
 
   //! Constant pointer type for PythonScalar convertible to both const T* and
@@ -42,9 +43,6 @@ namespace Rover {
   class PythonScalarConstPointer {
     public:
 
-      //! Constructs the object using a raw PythonScalar<T> constant pointer.
-      PythonScalarConstPointer(const PythonScalar<T>* ptr);
-
       //! Converts the pointer to const PythonScalar<T>*.
       operator const PythonScalar<T>*() const;
 
@@ -52,7 +50,11 @@ namespace Rover {
       operator const T*() const;
 
     private:
+      friend PythonScalar<T>;
+
       const PythonScalar<T>* m_ptr;
+
+      explicit PythonScalarConstPointer(const PythonScalar<T>* ptr);
   };
 
   //! Adapts a scalar type to pybind11::object by providing the one-way
@@ -132,12 +134,12 @@ namespace Rover {
 
   template<typename T>
   PythonScalarPointer<T> PythonScalar<T>::operator &() {
-    return this;
+    return PythonScalarPointer<T>(this);
   }
 
   template<typename T>
   PythonScalarConstPointer<T> PythonScalar<T>::operator &() const {
-    return this;
+    return PythonScalarConstPointer<T>(this);
   }
 
   template<typename T>

--- a/Python/Include/Scalar.hpp
+++ b/Python/Include/Scalar.hpp
@@ -149,17 +149,18 @@ namespace Rover {
   PythonScalar<T>::operator T&() {
     return m_value;
   }
-
-  template<typename T>
-  PythonScalar<T> abs(PythonScalar<T> scalar) {
-    return ::abs(static_cast<T>(scalar));
-  }
 }
 
 namespace pybind11 {
   template<typename T>
   object cast(const Rover::PythonScalar<T>& scalar) {
     return cast(static_cast<T>(scalar));
+  }
+
+  template<typename T>
+  Rover::PythonScalar<T> abs(Rover::PythonScalar<T> scalar) {
+    using namespace std;
+    return abs(static_cast<T>(scalar));
   }
 }
 

--- a/Python/Include/Scalar.hpp
+++ b/Python/Include/Scalar.hpp
@@ -88,7 +88,6 @@ namespace Rover {
     private:
       friend PythonScalarPointer<T>;
       friend PythonScalarConstPointer<T>;
-      template<typename T> friend PythonScalar<T> abs(PythonScalar<T>);
 
       T m_value;
   };
@@ -152,8 +151,7 @@ namespace Rover {
 
   template<typename T>
   PythonScalar<T> abs(PythonScalar<T> scalar) {
-    ::abs(scalar.m_value);
-    return std::move(scalar);
+    return ::abs(static_cast<T>(scalar));
   }
 }
 

--- a/Python/Include/Scalar.hpp
+++ b/Python/Include/Scalar.hpp
@@ -67,7 +67,7 @@ namespace Rover {
       PythonScalar() = default;
 
       //! Constructs a PythonScalar from a Python object.
-      PythonScalar(const pybind11::object& obj);
+      explicit PythonScalar(const pybind11::object& obj);
 
       //! Constructs a PythonScalar from an instance of the scalar.
       PythonScalar(T value);

--- a/Python/Include/Scalar.hpp
+++ b/Python/Include/Scalar.hpp
@@ -1,5 +1,6 @@
 #ifndef ROVER_PYTHON_SCALAR_HPP
 #define ROVER_PYTHON_SCALAR_HPP
+#include <cmath>
 #include <memory>
 #include <type_traits>
 #include <dlib/algs.h>
@@ -151,18 +152,20 @@ namespace Rover {
   PythonScalar<T>::operator T&() {
     return m_value;
   }
+
+namespace Details {
+  template<typename T>
+  Rover::PythonScalar<T> abs(Rover::PythonScalar<T> scalar) {
+    using namespace std;
+    return abs(static_cast<T>(scalar));
+  }
+}
 }
 
 namespace pybind11 {
   template<typename T>
   object cast(const Rover::PythonScalar<T>& scalar) {
     return cast(static_cast<T>(scalar));
-  }
-
-  template<typename T>
-  Rover::PythonScalar<T> abs(Rover::PythonScalar<T> scalar) {
-    using namespace std;
-    return abs(static_cast<T>(scalar));
   }
 }
 

--- a/Python/Include/Scalar.hpp
+++ b/Python/Include/Scalar.hpp
@@ -1,5 +1,6 @@
 #ifndef ROVER_PYTHON_SCALAR_HPP
 #define ROVER_PYTHON_SCALAR_HPP
+#include <memory>
 #include <type_traits>
 #include <dlib/algs.h>
 #include <pybind11/pybind11.h>
@@ -103,7 +104,7 @@ namespace Rover {
 
   template<typename T>
   PythonScalarPointer<T>::operator T*() const {
-    return &(m_ptr->m_value);
+    return std::addressof(m_ptr->m_value);
   }
 
   template<typename T>
@@ -118,7 +119,7 @@ namespace Rover {
 
   template<typename T>
   PythonScalarConstPointer<T>::operator const T*() const {
-    return &(m_ptr->m_value);
+    return std::addressof(m_ptr->m_value);
   }
 
   template<typename T>

--- a/Python/Include/Scalar.hpp
+++ b/Python/Include/Scalar.hpp
@@ -1,0 +1,175 @@
+#ifndef ROVER_PYTHON_SCALAR_HPP
+#define ROVER_PYTHON_SCALAR_HPP
+#include <type_traits>
+#include <dlib/algs.h>
+#include <pybind11/pybind11.h>
+
+namespace Rover {
+
+  //! PythonScalar forward declaration.
+  template<typename T>
+  class PythonScalar;
+
+  //! Pointer type for PythonScalar convertible to both T* and
+  //! PythonScalar<T>*.
+  /*
+    \tparam T The type of the scalar.
+  */
+  template<typename T>
+  class PythonScalarPointer {
+    public:
+
+      //! Constructs the object using a raw PythonScalar<T> pointer.
+      PythonScalarPointer(PythonScalar<T>* ptr);
+
+      //! Converts the pointer to PythonScalar<T>*.
+      operator PythonScalar<T>*() const;
+
+      //! Converts the pointer to T*.
+      operator T*() const;
+
+    private:
+      PythonScalar<T>* m_ptr;
+  };
+
+  //! Constant pointer type for PythonScalar convertible to both const T* and
+  //! const PythonScalar<T>*.
+  /*
+    \tparam T The type of the scalar.
+  */
+  template<typename T>
+  class PythonScalarConstPointer {
+    public:
+
+      //! Constructs the object using a raw PythonScalar<T> constant pointer.
+      PythonScalarConstPointer(const PythonScalar<T>* ptr);
+
+      //! Converts the pointer to const PythonScalar<T>*.
+      operator const PythonScalar<T>*() const;
+
+      //! Converts the pointer to const T*.
+      operator const T*() const;
+
+    private:
+      const PythonScalar<T>* m_ptr;
+  };
+
+  //! Adapts a scalar type to pybind11::object by providing the one-way
+  //! conversion from Python objects and forwarding scalar semantics.
+  /*
+    \tparam T The type of the scalar - an arithmetic type.
+  */
+  template<typename T>
+  class PythonScalar {
+    public:
+
+      //! Constructs an uninitialized PythonScalar.
+      PythonScalar() = default;
+
+      //! Constructs a PythonScalar from a Python object.
+      PythonScalar(const pybind11::object& obj);
+
+      //! Constructs a PythonScalar from an instance of the scalar.
+      PythonScalar(T value);
+
+      //! Converts the PythonScalar to the type of the scalar.
+      operator T() const;
+
+      //! Converts the PythonScalar to a reference to the scalar.
+      operator T&();
+
+      //! Produces a PythonScalarPointer corresponding to the PythonScalar.
+      PythonScalarPointer<T> operator &();
+
+      //! Produces a PythonScalarConstPointer corresponding to the
+      //! PythonScalar.
+      PythonScalarConstPointer<T> operator &() const;
+
+    private:
+      friend PythonScalarPointer<T>;
+      friend PythonScalarConstPointer<T>;
+      template<typename T> friend PythonScalar<T> abs(PythonScalar<T>);
+
+      T m_value;
+  };
+
+  template<typename T>
+  PythonScalarPointer<T>::PythonScalarPointer(PythonScalar<T>* ptr) 
+    : m_ptr(ptr) {}
+
+  template<typename T>
+  PythonScalarPointer<T>::operator PythonScalar<T>*() const {
+    return m_ptr;
+  }
+
+  template<typename T>
+  PythonScalarPointer<T>::operator T*() const {
+    return &(m_ptr->m_value);
+  }
+
+  template<typename T>
+  PythonScalarConstPointer<T>::PythonScalarConstPointer(const PythonScalar<T>*
+      ptr)
+    : m_ptr(ptr) {}
+
+  template<typename T>
+  PythonScalarConstPointer<T>::operator const PythonScalar<T>*() const {
+    return m_ptr;
+  }
+
+  template<typename T>
+  PythonScalarConstPointer<T>::operator const T*() const {
+    return &(m_ptr->m_value);
+  }
+
+  template<typename T>
+  PythonScalar<T>::PythonScalar(const pybind11::object& obj)
+    : m_value(obj.template cast<T>()) {}
+
+  template<typename T>
+  PythonScalar<T>::PythonScalar(T value)
+    : m_value(std::move(value)) {}
+
+  template<typename T>
+  PythonScalarPointer<T> PythonScalar<T>::operator &() {
+    return this;
+  }
+
+  template<typename T>
+  PythonScalarConstPointer<T> PythonScalar<T>::operator &() const {
+    return this;
+  }
+
+  template<typename T>
+  PythonScalar<T>::operator T() const {
+    return m_value;
+  }
+
+  template<typename T>
+  PythonScalar<T>::operator T&() {
+    return m_value;
+  }
+
+  template<typename T>
+  PythonScalar<T> abs(PythonScalar<T> scalar) {
+    ::abs(scalar.m_value);
+    return std::move(scalar);
+  }
+}
+
+namespace pybind11 {
+  template<typename T>
+  object cast(const Rover::PythonScalar<T>& scalar) {
+    return cast(static_cast<T>(scalar));
+  }
+}
+
+namespace dlib {
+  template<typename T>
+  class is_same_type<T, Rover::PythonScalar<T>> : private std::true_type {};
+
+  template<typename T>
+  class is_same_type<Rover::PythonScalar<T>, T> : private std::true_type {};
+}
+
+#endif

--- a/Python/Source/Arithmetics.cpp
+++ b/Python/Source/Arithmetics.cpp
@@ -17,6 +17,11 @@ namespace Rover::Details {
     static auto module = pybind11::module::import("operator");
     return module;
   }
+
+  pybind11::object apply_operator(const char* operator_name, const
+      pybind11::object& lhs, const pybind11::object& rhs) {
+    return import_operator().attr(operator_name)(lhs, rhs);
+  }
 }
 
 namespace pybind11 {


### PR DESCRIPTION
`PythonScalar `is already tested against `LinearRegressionModel `exports and it works seamlessly.
Changes to arithmetics were necessary to prevent the direct escalation of `PythonScalar<T>` to `pybind11::object`.
`LinearRegressionModel `exports are ready and will be pushed once this pull request is approved.