### PR TITLE
Factor Basis out of Model

### DIFF
--- a/Include/Rover/Basis.hpp
+++ b/Include/Rover/Basis.hpp
@@ -1,0 +1,195 @@
+#ifndef ROVER_BASIS_HPP
+#define ROVER_BASIS_HPP
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <vector>
+#include "Rover/Sample.hpp"
+#include "Rover/ScalarView.hpp"
+
+namespace Rover {
+
+  //! Basis of variables used to produce scalar encodings for samples.
+  /*!
+    \tparam S The type of the sample.
+    \tparam T The type of the scalar.
+  */
+  template<typename S, typename T>
+  class Basis {
+    public:
+
+      //! The type of the sample.
+      using Sample = S;
+
+      //! The type of the result.
+      using Result = typename Sample::Result;
+
+      //! The type of the arguments.
+      using Arguments = typename Sample::Arguments;
+
+      //! The type of the scalar.
+      using ScalarType = T;
+
+      //! The scalar type of the sample.
+      using ScalarSample = Rover::ScalarSample<T>;
+
+      //! The scalar type of the result.
+      using ScalarResult = typename ScalarSample::Result;
+
+      //! The scalar type of the arguments.
+      using ScalarArguments = typename ScalarSample::Arguments;
+
+      //! Builds a basis from a trial by finding appropriate elements.
+      /*!
+        \tparam Trial The type of the trial.
+        \param trail The trial.
+      */
+      template<typename Trial>
+      explicit Basis(const Trial& trial);
+
+      //! Converts arguments to the scalar type.
+      /*!
+        \param arguments The arguments to convert.
+      */
+      ScalarArguments apply(const Arguments& arguments) const;
+
+      //! Converts a sample to the scalar type.
+      /*!
+        \param sample The sample to convert.
+      */
+      ScalarSample apply(const Sample& sample) const;
+
+      //! Restores the original result from a scalar result.
+      /*!
+        \param result The scalar result.
+      */
+      auto restore_result(ScalarResult result) const;
+
+    private:
+      Sample m_elements;
+      std::vector<bool> m_to_negate;
+
+      ScalarResult result_cast(const Result& value) const;
+  };
+
+namespace Details {
+  template<typename R, typename X, typename Y>
+  constexpr std::enable_if_t<!std::is_same_v<std::decay_t<R>,
+      std::decay_t<X>> || !std::is_same_v<std::decay_t<R>, std::decay_t<Y>>,
+      bool> solve_basis(R&, std::vector<bool>::reference to_negate, const X&,
+      const Y&) {
+    return false;
+  }
+
+  template<typename R, typename X, typename Y>
+  std::enable_if_t<std::is_same_v<std::decay_t<R>, std::decay_t<X>> &&
+      std::is_same_v<std::decay_t<R>, std::decay_t<Y>>, bool>
+      solve_basis(R& r, std::vector<bool>::reference to_negate, const X& x,
+      const Y& y) {
+    if(x == y) {
+      return false;
+    }
+    if(x + y == x) {
+      r = x;
+      to_negate = x + y < y;
+    } else {
+      r = y;
+      to_negate = x + y < x;
+    }
+    return true;
+  }
+
+  template<typename C, typename V, typename B>
+  constexpr std::enable_if_t<!std::is_same_v<V, B>> apply_basis(C&,
+    bool to_negate, const V&, const B&) {}
+
+  template<typename C, typename V, typename B>
+  constexpr std::enable_if_t<std::is_same_v<V, B>> apply_basis(C& c,
+      bool to_negate, const V& v, const B& b) {
+    if(to_negate) {
+      c = -static_cast<C>(v / b);
+    } else {
+      c = static_cast<C>(v / b);
+    }
+  }
+}
+
+  template<typename S, typename T>
+  template<typename Trial>
+  Basis<S, T>::Basis(const Trial& trial)
+      : m_elements(trial[0]),
+        m_to_negate(1 + arguments_size(trial[0].m_arguments)) {
+    auto order = std::vector<std::size_t>(trial.size());
+    auto generator = std::mt19937(std::random_device()());
+    std::iota(order.begin(), order.end(), std::size_t(0));
+    visit_arguments([&](auto& result, auto i) {
+      std::shuffle(order.begin(), order.end(), generator);
+      const auto& first_arguments = trial[order[0]].m_arguments;
+      visit_arguments([&](const auto& lhs, auto j) {
+        if(i == j) {
+          auto to_break = false;
+          for(auto l = std::size_t(1); l < order.size() && !to_break; ++l) {
+            const auto& second_arguments = trial[order[l]].m_arguments;
+            visit_arguments([&](const auto& rhs, auto k) {
+              if(j == k && Details::solve_basis(result, m_to_negate[i + 1],
+                  lhs, rhs)) {
+                to_break = true;
+              }
+            }, second_arguments);
+          }
+        }
+      }, first_arguments);
+    }, m_elements.m_arguments);
+    std::shuffle(order.begin(), order.end(), std::move(generator));
+    const auto& first_result = trial[order[0]].m_result;
+    for(auto l = std::size_t(1); l < order.size(); ++l) {
+      const auto& second_result = trial[order[l]].m_result;
+      if(first_result != second_result) {
+        Details::solve_basis(m_elements.m_result, m_to_negate[0], first_result,
+          second_result);
+      }
+    }
+  }
+  
+  template<typename S, typename T>
+  typename Basis<S, T>::ScalarArguments Basis<S, T>::apply(const Arguments&
+      arguments) const {
+    auto result = ScalarArguments(arguments_size(arguments));
+    visit_arguments([&](const auto& arg, auto i) {
+      visit_arguments([&](const auto& identity, auto j) {
+        if(i == j) {
+          Details::apply_basis(result[i], m_to_negate[i + 1], arg, identity);
+        }
+      }, m_elements.m_arguments);
+    }, arguments);
+    return result;
+  }
+
+  template<typename S, typename T>
+  typename Basis<S, T>::ScalarSample Basis<S, T>::apply(const Sample& sample)
+      const {
+    auto arguments = apply(sample.m_arguments);
+    auto result = result_cast(sample.m_result);
+    return { result, arguments };
+  }
+
+  template<typename S, typename T>
+  auto Basis<S, T>::restore_result(ScalarResult value) const {
+    auto result = value * m_elements.m_result;
+    if(m_to_negate[0]) {
+      return -result;
+    } else {
+      return result;
+    }
+  }
+
+  template<typename S, typename T>
+  typename Basis<S, T>::ScalarResult Basis<S, T>::result_cast(const Result&
+      value) const {
+    auto result = ScalarResult();
+    Details::apply_basis(result, m_to_negate[0], value, m_elements.m_result);
+    return result;
+  }
+}
+
+#endif

--- a/Include/Rover/Model.hpp
+++ b/Include/Rover/Model.hpp
@@ -42,7 +42,6 @@ namespace Rover {
       auto operator ()(const Arguments& args) const;
 
     private:
-      //! The type of the basis.
       using Basis = Rover::Basis<Sample, ComputationType>;
       
       Basis m_basis;

--- a/Include/Rover/Model.hpp
+++ b/Include/Rover/Model.hpp
@@ -1,54 +1,8 @@
 #ifndef ROVER_MODEL_HPP
 #define ROVER_MODEL_HPP
-#include <algorithm>
-#include <numeric>
-#include <random>
 #include <type_traits>
-#include <vector>
-#include "Rover/Sample.hpp"
+#include "Rover/Basis.hpp"
 #include "Rover/ScalarView.hpp"
-
-namespace {
-  template<typename R, typename X, typename Y>
-  constexpr std::enable_if_t<!std::is_same_v<std::decay_t<R>,
-      std::decay_t<X>> || !std::is_same_v<std::decay_t<R>, std::decay_t<Y>>,
-      bool> solve_basis(R&, std::vector<bool>::reference to_negate, const X&,
-      const Y&) {
-    return false;
-  }
-
-  template<typename R, typename X, typename Y>
-  std::enable_if_t<std::is_same_v<std::decay_t<R>, std::decay_t<X>> &&
-      std::is_same_v<std::decay_t<R>, std::decay_t<Y>>, bool>
-      solve_basis(R& r, std::vector<bool>::reference to_negate, const X& x,
-      const Y& y) {
-    if(x == y) {
-      return false;
-    }
-    if(x + y == x) {
-      r = x;
-      to_negate = x + y < y;
-    } else {
-      r = y;
-      to_negate = x + y < x;
-    }
-    return true;
-  }
-
-  template<typename C, typename V, typename B>
-  constexpr std::enable_if_t<!std::is_same_v<V, B>> apply_basis(C&,
-    bool to_negate, const V&, const B&) {}
-
-  template<typename C, typename V, typename B>
-  constexpr std::enable_if_t<std::is_same_v<V, B>> apply_basis(C& c,
-      bool to_negate, const V& v, const B& b) {
-    if(to_negate) {
-      c = -static_cast<C>(v / b);
-    } else {
-      c = static_cast<C>(v / b);
-    }
-  }
-}
 
 namespace Rover { 
 
@@ -76,9 +30,6 @@ namespace Rover {
       //! The type of a sample's arguments.
       using Arguments = typename Sample::Arguments;
 
-      //! The type of a sample's result.
-      using Result = typename Sample::Result;
-
       //! Creates a Model.
       /*!
         \param trial The trial.
@@ -91,121 +42,30 @@ namespace Rover {
       auto operator ()(const Arguments& args) const;
 
     private:
-      using ScalarSample = Rover::ScalarSample<ComputationType>;
-      using ScalarArguments = typename ScalarSample::Arguments;
-      using ScalarResult = typename ScalarSample::Result;
-
-      struct Basis {
-        Sample m_elements;
-        std::vector<bool> m_to_negate;
-      };
-
+      //! The type of the basis.
+      using Basis = Rover::Basis<Sample, ComputationType>;
+      
       Basis m_basis;
       Algorithm m_algorithm;
-
-      static Basis compute_basis(const Trial& trial);
-      ScalarSample sample_cast(const Sample& sample) const;
-      ScalarArguments arguments_cast(const Arguments& sample) const;
-      ScalarResult result_cast(const Result& value) const;
-      auto retrieve_result(ScalarResult value) const;
   };
 
   template<typename A, typename T>
   template<typename... AlgoArgFwd>
   Model<A, T>::Model(const Trial& trial, AlgoArgFwd&&... args)
-      : m_basis(compute_basis(trial)),
+      : m_basis(trial),
         m_algorithm(std::forward<AlgoArgFwd>(args)...) {
     auto view = ScalarView([&](std::size_t i) {
-      return sample_cast(trial[i]);
+      return m_basis.apply(trial[i]);
     }, trial.size());
     m_algorithm.learn(std::move(view));
   }
 
   template<typename A, typename T>
-  auto Model<A, T>::operator ()(const Arguments& args)
-      const {
-    auto arguments = arguments_cast(args);
+  auto Model<A, T>::operator ()(const Arguments& args) const {
+    auto arguments = m_basis.apply(args);
     auto value = m_algorithm.predict(arguments);
-    auto result = retrieve_result(value);
+    auto result = m_basis.restore_result(value);
     return result;
-  }
-
-  template<typename A, typename T>
-  typename Model<A, T>::Basis Model<A, T>::compute_basis(const Trial& trial) {
-    auto order = std::vector<std::size_t>(trial.size());
-    auto generator = std::mt19937(std::random_device()());
-    std::iota(order.begin(), order.end(), std::size_t(0));
-    auto basis = Basis{ trial[0], std::vector<bool>(1 + arguments_size(
-      trial[0].m_arguments)) };
-    auto& elements = basis.m_elements;
-    auto& to_negate = basis.m_to_negate;
-    visit_arguments([&](auto& result, auto i) {
-      std::shuffle(order.begin(), order.end(), generator);
-      const auto& first_arguments = trial[order[0]].m_arguments;
-      visit_arguments([&](const auto& lhs, auto j) {
-        if(i == j) {
-          auto to_break = false;
-          for(auto l = std::size_t(1); l < order.size() && !to_break; ++l) {
-            const auto& second_arguments = trial[order[l]].m_arguments;
-            visit_arguments([&](const auto& rhs, auto k) {
-              if(j == k && solve_basis(result, to_negate[i + 1], lhs, rhs)) {
-                to_break = true;
-              }
-            }, second_arguments);
-          }
-        }
-      }, first_arguments);
-    }, elements.m_arguments);
-    std::shuffle(order.begin(), order.end(), std::move(generator));
-    const auto& first_result = trial[order[0]].m_result;
-    for(auto l = std::size_t(1); l < order.size(); ++l) {
-      const auto& second_result = trial[order[l]].m_result;
-      if(first_result != second_result) {
-        solve_basis(elements.m_result, to_negate[0], first_result, second_result);
-      }
-    }
-    return basis;
-  }
-  
-  template<typename A, typename T>
-  typename Model<A, T>::ScalarSample Model<A, T>::sample_cast(
-      const Sample& sample) const {
-    auto arguments = arguments_cast(sample.m_arguments);
-    auto result = result_cast(sample.m_result);
-    return { result, arguments };
-  }
-
-  template<typename A, typename T>
-  typename Model<A, T>::ScalarArguments Model<A, T>::arguments_cast(
-      const Arguments& arguments) const {
-    auto result = ScalarArguments(arguments_size(arguments));
-    visit_arguments([&](const auto& arg, auto i) {
-      visit_arguments([&](const auto& identity, auto j) {
-        if(i == j) {
-          apply_basis(result[i], m_basis.m_to_negate[i + 1], arg, identity);
-        }
-      }, m_basis.m_elements.m_arguments);
-    }, arguments);
-    return result;
-  }
-
-  template<typename A, typename T>
-  typename Model<A, T>::ScalarResult Model<A, T>::result_cast(
-      const Result& value) const {
-    auto result = ScalarResult();
-    apply_basis(result, m_basis.m_to_negate[0], value,
-      m_basis.m_elements.m_result);
-    return result;
-  }
-
-  template<typename A, typename T>
-  auto Model<A, T>::retrieve_result(ScalarResult value) const {
-    auto result = value * m_basis.m_elements.m_result;
-    if(m_basis.m_to_negate[0]) {
-      return -result;
-    } else {
-      return result;
-    }
   }
 }
 

--- a/Tests/Source/BasisTester.cpp
+++ b/Tests/Source/BasisTester.cpp
@@ -1,0 +1,187 @@
+#include <catch.hpp>
+#include "Rover/Basis.hpp"
+#include "Rover/ListTrial.hpp"
+#include "Rover/Sample.hpp"
+
+using namespace Rover;
+
+namespace {
+  template<typename B, typename T>
+  void check_result(const B& basis, T result) {
+    REQUIRE(basis.restore_result(basis.apply({ result, { 1. } }).m_result) ==
+      result);
+  }
+
+  template<typename B>
+  void check_result_positive(const B& basis) {
+    check_result(basis, 0.5);
+    check_result(basis, 1.);
+    check_result(basis, 2.);
+  }
+
+  template<typename B>
+  void check_result_negative(const B& basis) {
+    check_result(basis, -0.5);
+    check_result(basis, -1.);
+    check_result(basis, -2.);
+  }
+
+  template<typename B>
+  void check_result_singular(const B& basis) {
+    check_result(basis, 0.);
+  }
+
+  template<typename B>
+  void check_result(const B& basis) {
+    check_result_positive(basis);
+    check_result_negative(basis);
+    check_result_singular(basis);
+  }
+}
+
+TEST_CASE("test_basis_positive_elements", "[Basis]") {
+  SECTION("Two samples.") {
+    auto trial = ListTrial<Sample<double, double>>();
+    trial.insert({ 2., { 4. } });
+    trial.insert({ 4., { 8. } });
+    for(auto i = 0; i < 100; ++i) {
+      auto basis = Basis<Sample<double, double>, double>(trial);
+      auto sample = basis.apply({ 1., { 1. } });
+      REQUIRE((sample.m_result == Approx(0.5) || sample.m_result ==
+        Approx(0.25)));
+      REQUIRE(sample.m_arguments.size() == 1);
+      REQUIRE((sample.m_arguments[0] == Approx(0.25) ||
+        sample.m_arguments[0] == Approx(0.125)));
+      auto arguments = basis.apply(Sample<double, double>::Arguments{ 1. });
+      REQUIRE(sample.m_arguments == arguments);
+      check_result_positive(basis);
+    }
+  }
+  SECTION("Three samples.") {
+    auto trial = ListTrial<Sample<double, double>>();
+    trial.insert({ 1., { 1. } });
+    trial.insert({ 2., { 4. } });
+    trial.insert({ 4., { 8. } });
+    for(auto i = 0; i < 100; ++i) {
+      auto basis = Basis<Sample<double, double>, double>(trial);
+      auto sample = basis.apply({ 1., { 1. } });
+      REQUIRE((sample.m_result == Approx(0.5) || sample.m_result ==
+        Approx(0.25) || sample.m_result == Approx(1.)));
+      REQUIRE(sample.m_arguments.size() == 1);
+      REQUIRE((sample.m_arguments[0] == Approx(0.25) ||
+        sample.m_arguments[0] == Approx(0.125) ||
+        sample.m_arguments[0] == Approx(1.)));
+      auto arguments = basis.apply(Sample<double, double>::Arguments{ 1. });
+      REQUIRE(sample.m_arguments == arguments);
+      check_result_positive(basis);
+    }
+  }
+}
+
+TEST_CASE("test_basis_singular_elements", "[Basis]") {
+  SECTION("Apply to singlular.") {
+    auto trial = ListTrial<Sample<double, double>>();
+    trial.insert({ 2., { 4. } });
+    trial.insert({ 4., { 8. } });
+    for(auto i = 0; i < 100; ++i) {
+      auto basis = Basis<Sample<double, double>, double>(trial);
+      auto sample = basis.apply({ 0., { 0. } });
+      REQUIRE(sample.m_result == Approx(0.));
+      REQUIRE(sample.m_arguments.size() == 1);
+      REQUIRE(sample.m_arguments[0] == Approx(0.));
+      auto arguments = basis.apply(Sample<double, double>::Arguments{ 0. });
+      REQUIRE(sample.m_arguments == arguments);
+      check_result_singular(basis);
+    }
+  }
+  SECTION("Avoid singular basis.") {
+    auto trial = ListTrial<Sample<double, double>>();
+    trial.insert({ 2., { 4. } });
+    trial.insert({ 0., { 0. } });
+    for(auto i = 0; i < 100; ++i) {
+      auto basis = Basis<Sample<double, double>, double>(trial);
+      auto sample = basis.apply({ 1., { 1. } });
+      REQUIRE(sample.m_result == Approx(0.5));
+      REQUIRE(sample.m_arguments.size() == 1);
+      REQUIRE(sample.m_arguments[0] == Approx(0.25));
+      auto arguments = basis.apply(Sample<double, double>::Arguments{ 1. });
+      REQUIRE(sample.m_arguments == arguments);
+      check_result_positive(basis);
+    }
+  }
+}
+
+TEST_CASE("test_basis_negative_elements", "[Basis]") {
+  SECTION("Apply to negative.") {
+    auto trial = ListTrial<Sample<double, double>>();
+    trial.insert({ 2., { 4. } });
+    trial.insert({ 4., { 8. } });
+    for(auto i = 0; i < 100; ++i) {
+      auto basis = Basis<Sample<double, double>, double>(trial);
+      auto sample = basis.apply({ -1., { -1. } });
+      REQUIRE((sample.m_result == Approx(-0.5) || sample.m_result ==
+        Approx(-0.25)));
+      REQUIRE(sample.m_arguments.size() == 1);
+      REQUIRE((sample.m_arguments[0] == Approx(-0.25) ||
+        sample.m_arguments[0] == Approx(-0.125)));
+      auto arguments = basis.apply(Sample<double, double>::Arguments{ -1. });
+      REQUIRE(sample.m_arguments == arguments);
+      check_result_negative(basis);
+    }
+  }
+  SECTION("Negative elements only.") {
+    auto trial = ListTrial<Sample<double, double>>();
+    trial.insert({ -2., { -4. } });
+    trial.insert({ -4., { -8. } });
+    for(auto i = 0; i < 100; ++i) {
+      auto basis = Basis<Sample<double, double>, double>(trial);
+      auto positive_sample = basis.apply({ 1., { 1. } });
+      REQUIRE((positive_sample.m_result == Approx(0.5) ||
+        positive_sample.m_result == Approx(0.25)));
+      REQUIRE(positive_sample.m_arguments.size() == 1);
+      REQUIRE((positive_sample.m_arguments[0] == Approx(0.25) ||
+        positive_sample.m_arguments[0] == Approx(0.125)));
+      auto positive_arguments = basis.apply(
+        Sample<double, double>::Arguments{ 1. });
+      REQUIRE(positive_sample.m_arguments == positive_arguments);
+      auto negative_sample = basis.apply({ -1., { -1. } });
+      REQUIRE((negative_sample.m_result == Approx(-0.5) ||
+        negative_sample.m_result == Approx(-0.25)));
+      REQUIRE(negative_sample.m_arguments.size() == 1);
+      REQUIRE((negative_sample.m_arguments[0] == Approx(-0.25) ||
+        negative_sample.m_arguments[0] == Approx(-0.125)));
+      auto negative_arguments = basis.apply(
+        Sample<double, double>::Arguments{ -1. });
+      REQUIRE(negative_sample.m_arguments == negative_arguments);
+      check_result(basis);
+    }
+  }
+  SECTION("Positive, negative, and singular elements.") {
+    auto trial = ListTrial<Sample<double, double>>();
+    trial.insert({ 0., { 0. } });
+    trial.insert({ 2., { 4. } });
+    trial.insert({ -4., { -8. } });
+    for(auto i = 0; i < 100; ++i) {
+      auto basis = Basis<Sample<double, double>, double>(trial);
+      auto positive_sample = basis.apply({ 1., { 1. } });
+      REQUIRE((positive_sample.m_result == Approx(0.5) ||
+        positive_sample.m_result == Approx(0.25)));
+      REQUIRE(positive_sample.m_arguments.size() == 1);
+      REQUIRE((positive_sample.m_arguments[0] == Approx(0.25) ||
+        positive_sample.m_arguments[0] == Approx(0.125)));
+      auto positive_arguments = basis.apply(
+        Sample<double, double>::Arguments{ 1. });
+      REQUIRE(positive_sample.m_arguments == positive_arguments);
+      auto negative_sample = basis.apply({ -1., { -1. } });
+      REQUIRE((negative_sample.m_result == Approx(-0.5) ||
+        negative_sample.m_result == Approx(-0.25)));
+      REQUIRE(negative_sample.m_arguments.size() == 1);
+      REQUIRE((negative_sample.m_arguments[0] == Approx(-0.25) ||
+        negative_sample.m_arguments[0] == Approx(-0.125)));
+      auto negative_arguments = basis.apply(
+        Sample<double, double>::Arguments{ -1. });
+      REQUIRE(negative_sample.m_arguments == negative_arguments);
+      check_result(basis);
+    }
+  }
+}


### PR DESCRIPTION
Now it is also possible to exclude the `Trial` type from the `Model` template, and parameterize it with the Sample type instead. It further reduces the need for `TrialView` (it becomes unnecessary even for Python exports), and, in general, there is no good reason for `Model` to depend on `Trial`.
However, I am keeping it the same for now to avoid cluttering `Model` instantiations: replacing the `Trial` parameter with `Sample` will make it necessary to explicitly specify the `Sample` type every time.