### PR TITLE
Support categorical elements in Basis

### DIFF
--- a/Include/Rover/Basis.hpp
+++ b/Include/Rover/Basis.hpp
@@ -3,11 +3,87 @@
 #include <algorithm>
 #include <numeric>
 #include <random>
+#include <tuple>
+#include <variant>
 #include <vector>
+#include "Rover/Factor.hpp"
 #include "Rover/Sample.hpp"
 #include "Rover/ScalarView.hpp"
+#include "Rover/VariableTraits.hpp"
 
 namespace Rover {
+namespace Details {
+  template<typename T>
+  struct add_factor;
+
+  template<typename... T>
+  struct add_factor<std::tuple<T...>> {
+    using type = std::tuple<std::variant<T, Factor<T>>...>;
+  };
+
+  template<typename T>
+  using add_factor_t = typename add_factor<T>::type;
+}
+
+  //! Arguments held by basis, allowing for both value element and factor
+  //! support.
+  /*!
+    \tparam A The type of the arguments from the original sample.
+  */
+  template<typename A>
+  class BasisArguments {
+    public:
+
+      //! Creates BasisArguments using original arguments.
+      /*!
+        \param args The original arguments.
+      */
+      template<typename ArgumentsFwd>
+      explicit BasisArguments(ArgumentsFwd&& args);
+
+      //! Makes the argument at a given index a value element and sets the
+      //! value.
+      /*!
+        \param index The index of the element to set.
+        \param value The value of the element.
+      */
+      template<typename T>
+      void set_value(std::size_t index, T&& value);
+
+      //! Adds a category to the factor at a given index. If the element at
+      //! the index is not currently a factor, makes it a factor.
+      /*!
+        \param index The index of the element to set.
+        \param category The category to add.
+      */
+      template<typename T>
+      void add_category(std::size_t index, T&& category);
+
+      //! Returns the number of arguments.
+      std::size_t size() const;
+
+      //! Applies a function template to every element.
+      /*!
+        \param func The function template.
+      */
+      template<typename Func>
+      void visit(Func&& func);
+
+      //! Applies a function template to every element.
+      /*!
+        \param func The function template.
+      */
+      template<typename Func>
+      void visit(Func&& func) const;
+
+    private:
+      using Arguments = Details::add_factor_t<A>;
+
+      Arguments m_arguments;
+  };
+
+  template<typename ArgumentsFwd>
+  BasisArguments(ArgumentsFwd&&) -> BasisArguments<std::decay_t<ArgumentsFwd>>;
 
   //! Basis of variables used to produce scalar encodings for samples.
   /*!
@@ -66,9 +142,14 @@ namespace Rover {
       auto restore_result(ScalarResult result) const;
 
     private:
-      Sample m_elements;
+      Result m_result;
+      BasisArguments<Arguments> m_arguments;
       std::vector<bool> m_to_negate;
 
+      static std::vector<std::size_t> find_categorical(const Arguments& args);
+      template<typename Trial>
+      void compute_factors(const Trial& trial, const std::vector<std::size_t>&
+        indexes);
       ScalarResult result_cast(const Result& value) const;
   };
 
@@ -99,30 +180,163 @@ namespace Details {
     return true;
   }
 
-  template<typename C, typename V, typename B>
-  constexpr std::enable_if_t<!std::is_same_v<V, B>> apply_basis(C&,
-    bool to_negate, const V&, const B&) {}
+  template<typename R, typename V, typename B, typename C = void>
+  struct BasisApplier {
+    static void apply(R&, bool, const V&, const B&) {}
+  };
 
-  template<typename C, typename V, typename B>
-  constexpr std::enable_if_t<std::is_same_v<V, B>> apply_basis(C& c,
-      bool to_negate, const V& v, const B& b) {
-    if(to_negate) {
-      c = -static_cast<C>(v / b);
-    } else {
-      c = static_cast<C>(v / b);
+  template<typename R, typename V, typename B>
+  struct BasisApplier<R, V, B, std::enable_if_t<continuous<R, V>::value &&
+      std::is_same_v<V, B>>> {
+    static void apply(R& r, bool to_negate, const V& v, const B& b) {
+      if(to_negate) {
+        r = -static_cast<R>(v / b);
+      } else {
+        r = static_cast<R>(v / b);
+      }
     }
+  };
+
+  template<typename R, typename V, typename B>
+  void apply_basis(R& r, bool to_negate, const V& v, const B& b) {
+    BasisApplier<R, V, B>::apply(r, to_negate, v, b);
+  }
+
+  template<typename A, typename T, typename C = void>
+  struct ValueUploader {
+    template<typename ValueFwd>
+    static void upload(A& arg, ValueFwd&& value) {}
+  };
+
+  template<typename A, typename T>
+  struct ValueUploader<A, T, std::enable_if_t<std::is_same_v<decltype(
+      std::declval<A>() = std::declval<T>()), A&>>> {
+    template<typename ValueFwd>
+    static void upload(A& arg, ValueFwd&& value) {
+      arg = std::forward<ValueFwd>(value);
+    }
+  };
+
+  template<typename A, typename T>
+  void upload_value(A& arg, T&& value) {
+    ValueUploader<A, std::decay_t<T>>::upload(arg, std::forward<T>(value));
+  }
+
+  template<typename A, typename T, typename C = void>
+  struct CategoryUploader {
+    template<typename CategoryFwd>
+    static void upload(A& arg, CategoryFwd&& category) {}
+  };
+
+  template<typename A, typename T>
+  struct CategoryUploader<A, T, std::enable_if_t<std::is_same_v<decltype(
+      std::declval<A>() = std::declval<Factor<T>>()), A&>>> {
+    template<typename CategoryFwd>
+    static void upload(A& arg, CategoryFwd&& category) {
+      auto visited = false;
+      static_assert(std::is_same_v<A, std::variant<T, Factor<T>>>);
+      std::visit([&](auto& factor) {
+        if constexpr(std::is_same_v<std::decay_t<decltype(factor)>,
+            Factor<T>>) {
+          factor.add_category(std::forward<CategoryFwd>(category));
+          visited = true;
+        }
+      }, arg);
+      if(!visited) {
+        auto factor = Factor<T>();
+        factor.add_category(std::forward<CategoryFwd>(category));
+        arg = std::move(factor);
+      }
+    }
+  };
+
+  template<typename A, typename T>
+  void upload_category(A& arg, T&& category) {
+    CategoryUploader<A, std::decay_t<T>>::upload(arg, std::forward<T>(
+      category));
+  }
+
+  template<typename F, typename T>
+  struct DimensionFinder {
+    static std::optional<std::size_t> find(const F&, const T&) {
+      return std::nullopt;
+    }
+  };
+
+  template<typename T>
+  struct DimensionFinder<Factor<T>, T> {
+    static std::optional<std::size_t> find(const Factor<T>& factor, const T&
+        category) {
+      return factor.find_dimension(category);
+    }
+  };
+
+  template<typename F, typename T>
+  std::optional<std::size_t> find_dimension(const F& factor, const T&
+      category) {
+    return DimensionFinder<F, T>::find(factor, category);
   }
 }
+
+  template<typename A>
+  template<typename ArgumentsFwd>
+  BasisArguments<A>::BasisArguments(ArgumentsFwd&& args)
+    : m_arguments(std::forward<ArgumentsFwd>(args)) {}
+
+  template<typename A>
+  template<typename T>
+  void BasisArguments<A>::set_value(std::size_t index, T&& value) {
+    visit_arguments([&](auto& arg, auto i) {
+      if(index == i) {
+        Details::upload_value(arg, std::forward<T>(value));
+      }
+    }, m_arguments);
+  }
+
+  template<typename A>
+  template<typename T>
+  void BasisArguments<A>::add_category(std::size_t index, T&& category) {
+    visit_arguments([&](auto& arg, auto i) {
+      if(index == i) {
+        Details::upload_category(arg, std::forward<T>(category));
+      }
+    }, m_arguments);
+  }
+
+  template<typename A>
+  std::size_t BasisArguments<A>::size() const {
+    return arguments_size(m_arguments);
+  }
+
+  template<typename A>
+  template<typename Func>
+  void BasisArguments<A>::visit(Func&& func) {
+    visit_arguments(std::forward<Func>(func), m_arguments);
+  }
+
+  template<typename A>
+  template<typename Func>
+  void BasisArguments<A>::visit(Func&& func) const {
+    visit_arguments(std::forward<Func>(func), m_arguments);
+  }
 
   template<typename S, typename T>
   template<typename Trial>
   Basis<S, T>::Basis(const Trial& trial)
-      : m_elements(trial[0]),
-        m_to_negate(1 + arguments_size(trial[0].m_arguments)) {
+      : m_result(trial[0].m_result),
+        m_arguments(trial[0].m_arguments),
+        m_to_negate(1 + m_arguments.size()) {
     auto order = std::vector<std::size_t>(trial.size());
     auto generator = std::mt19937(std::random_device()());
+    auto factor_indexes = find_categorical(trial[0].m_arguments);
     std::iota(order.begin(), order.end(), std::size_t(0));
-    visit_arguments([&](auto& result, auto i) {
+    for(auto i = std::size_t(0), last_factor_index = std::size_t(0); i <
+        m_arguments.size(); ++i) {
+      if(last_factor_index < factor_indexes.size() &&
+          factor_indexes[last_factor_index] == i) {
+        ++last_factor_index;
+        continue;
+      }
       std::shuffle(order.begin(), order.end(), generator);
       const auto& first_arguments = trial[order[0]].m_arguments;
       visit_arguments([&](const auto& lhs, auto j) {
@@ -131,36 +345,60 @@ namespace Details {
           for(auto l = std::size_t(1); l < order.size() && !to_break; ++l) {
             const auto& second_arguments = trial[order[l]].m_arguments;
             visit_arguments([&](const auto& rhs, auto k) {
-              if(j == k && Details::solve_basis(result, m_to_negate[i + 1],
+              auto val = lhs;
+              if(j == k && Details::solve_basis(val, m_to_negate[i + 1],
                   lhs, rhs)) {
+                m_arguments.set_value(i, std::move(val));
                 to_break = true;
               }
             }, second_arguments);
           }
         }
       }, first_arguments);
-    }, m_elements.m_arguments);
+    }
     std::shuffle(order.begin(), order.end(), std::move(generator));
     const auto& first_result = trial[order[0]].m_result;
     for(auto l = std::size_t(1); l < order.size(); ++l) {
       const auto& second_result = trial[order[l]].m_result;
       if(first_result != second_result) {
-        Details::solve_basis(m_elements.m_result, m_to_negate[0], first_result,
+        Details::solve_basis(m_result, m_to_negate[0], first_result,
           second_result);
       }
+    }
+    if(!factor_indexes.empty()) {
+      compute_factors(trial, factor_indexes);
     }
   }
   
   template<typename S, typename T>
   typename Basis<S, T>::ScalarArguments Basis<S, T>::apply(const Arguments&
       arguments) const {
-    auto result = ScalarArguments(arguments_size(arguments));
+    auto result = ScalarArguments();
     visit_arguments([&](const auto& arg, auto i) {
-      visit_arguments([&](const auto& identity, auto j) {
+      m_arguments.visit([&](const auto& identity, auto j) {
         if(i == j) {
-          Details::apply_basis(result[i], m_to_negate[i + 1], arg, identity);
+          std::visit([&](const auto& val) {
+            if constexpr(is_factor_v<std::decay_t<decltype(val)>>) {
+              auto dimension = Details::find_dimension(val, arg);
+              if(!dimension) {
+                result.insert(result.end(), val.size() - 1,
+                  static_cast<ScalarType>(1.) / val.size());
+              } else {
+                for(auto i = std::size_t(1); i < val.size(); ++i) {
+                  if(i == *dimension) {
+                    result.push_back(static_cast<ScalarType>(1.));
+                  } else {
+                    result.push_back(static_cast<ScalarType>(0.));
+                  }
+                }
+              }
+            } else {
+              result.push_back(ScalarType{});
+              Details::apply_basis(result.back(), m_to_negate[i + 1], arg, val);
+            }
+          }, identity);
         }
-      }, m_elements.m_arguments);
+      });
     }, arguments);
     return result;
   }
@@ -175,7 +413,7 @@ namespace Details {
 
   template<typename S, typename T>
   auto Basis<S, T>::restore_result(ScalarResult value) const {
-    auto result = value * m_elements.m_result;
+    auto result = value * m_result;
     if(m_to_negate[0]) {
       return -result;
     } else {
@@ -184,10 +422,38 @@ namespace Details {
   }
 
   template<typename S, typename T>
+  std::vector<std::size_t> Basis<S, T>::find_categorical(const Arguments&
+      args) {
+    auto result = std::vector<std::size_t>();
+    visit_arguments([&](const auto& value, auto index) {
+      if(!is_continuous<ScalarType>(value)) {
+        result.push_back(index);
+      }
+    }, args);
+    return result;
+  }
+
+  template<typename S, typename T>
+  template<typename Trial>
+  void Basis<S, T>::compute_factors(const Trial& trial,
+      const std::vector<std::size_t>& indexes) {
+    for(auto& sample : trial) {
+      auto last_factor_index = std::size_t(0);
+      visit_arguments([&](const auto& value, auto index) {
+        if(last_factor_index < indexes.size() && index ==
+            indexes[last_factor_index]) {
+          m_arguments.add_category(index, value);
+          ++last_factor_index;
+        }
+      }, sample.m_arguments);
+    }
+  }
+
+  template<typename S, typename T>
   typename Basis<S, T>::ScalarResult Basis<S, T>::result_cast(const Result&
       value) const {
     auto result = ScalarResult();
-    Details::apply_basis(result, m_to_negate[0], value, m_elements.m_result);
+    Details::apply_basis(result, m_to_negate[0], value, m_result);
     return result;
   }
 }

--- a/Include/Rover/Basis.hpp
+++ b/Include/Rover/Basis.hpp
@@ -38,8 +38,7 @@ namespace Details {
       /*!
         \param args The original arguments.
       */
-      template<typename ArgumentsFwd>
-      explicit BasisArguments(ArgumentsFwd&& args);
+      explicit BasisArguments(const A& args);
 
       //! Makes the argument at a given index a value element and sets the
       //! value.
@@ -279,9 +278,8 @@ namespace Details {
 }
 
   template<typename A>
-  template<typename ArgumentsFwd>
-  BasisArguments<A>::BasisArguments(ArgumentsFwd&& args)
-    : m_arguments(std::forward<ArgumentsFwd>(args)) {}
+  BasisArguments<A>::BasisArguments(const A& args)
+    : m_arguments(args) {}
 
   template<typename A>
   template<typename T>

--- a/Include/Rover/Factor.hpp
+++ b/Include/Rover/Factor.hpp
@@ -35,9 +35,26 @@ namespace Rover {
       */
       std::optional<int> find_dimension(const Type& category) const;
 
+      //! Returns the number of registered categories.
+      std::size_t size() const;
+
     private:
       std::vector<Type> m_categories;
   };
+
+  //! Type trait to check whether a given type is factor.
+  /*!
+    \tparam T The type to check.
+  */
+  template<typename T>
+  struct is_factor;
+
+  //! Type trait to check whether a given type is factor.
+  /*!
+    \tparam T The type to check.
+  */
+  template<typename T>
+  inline constexpr bool is_factor_v = is_factor<T>::value;
 
 namespace Details{
   template<typename T, typename = void>
@@ -88,6 +105,9 @@ namespace Details{
       */
       std::optional<int> find_dimension(const Type& category) const;
 
+      //! Returns the number of registered categories.
+      std::size_t size() const;
+
     private:
       std::unordered_map<Type, int> m_map;
   };
@@ -120,6 +140,9 @@ namespace Details{
       */
       std::optional<int> find_dimension(const Type& category) const;
 
+      //! Returns the number of registered categories.
+      std::size_t size() const;
+
     private:
       std::map<Type, int> m_map;
   };
@@ -143,6 +166,11 @@ namespace Details{
     }
   }
 
+  template<typename T, typename C>
+  std::size_t Factor<T, C>::size() const {
+    return m_categories.size();
+  }
+
   template<typename T>
   void Factor<T, std::enable_if_t<Details::is_hashable_v<T>>>::add_category(
       const Type& category) {
@@ -158,6 +186,12 @@ namespace Details{
     } else {
       return it->second;
     }
+  }
+
+  template<typename T>
+  std::size_t Factor<T, std::enable_if_t<Details::is_hashable_v<
+      T>>>::size() const {
+    return m_map.size();
   }
 
   template<typename T>
@@ -181,6 +215,18 @@ namespace Details{
       return it->second;
     }
   }
+
+  template<typename T>
+  std::size_t Factor<T, std::enable_if_t<!Details::is_hashable_v<T> &&
+      Details::is_comparable_v<T>>>::size() const {
+    return m_map.size();
+  }
+
+  template<typename T>
+  struct is_factor : std::false_type {};
+
+  template<typename T>
+  struct is_factor<Factor<T>> : std::true_type {};
 }
 
 #endif

--- a/Python/Include/Basis.hpp
+++ b/Python/Include/Basis.hpp
@@ -1,0 +1,71 @@
+#ifndef ROVER_PYTHON_BASIS_HPP
+#define ROVER_PYTHON_BASIS_HPP
+#include <type_traits>
+#include <variant>
+#include <vector>
+#include <pybind11/pybind11.h>
+#include "Rover/Basis.hpp"
+#include "Rover/Factor.hpp"
+#include "Sample.hpp"
+
+namespace Rover {
+
+  //! Specializes BasisArguments for PythonSample arguments.
+  template<>
+  class BasisArguments<PythonSample::Arguments> {
+    public:
+
+      explicit BasisArguments(const PythonSample::Arguments& args)
+          : m_arguments(args.size()) {
+        for(auto i = std::size_t(0); i < args.size(); ++i) {
+          m_arguments[i] = args[i];
+        }
+      }
+
+      template<typename T>
+      void set_value(std::size_t index, T&& value) {
+        m_arguments[index] = std::forward<T>(value);
+      }
+
+      template<typename T>
+      void add_category(std::size_t index, T&& category) {
+        auto visited = false;
+        std::visit([&](auto& factor) {
+          if constexpr(std::is_same_v<std::decay_t<decltype(factor)>,
+             Factor<pybind11::object>>) {
+            factor.add_category(std::forward<T>(category));
+            visited = true;
+          }
+        }, m_arguments[index]);
+        if(!visited) {
+          auto factor = Factor<pybind11::object>();
+          factor.add_category(std::forward<T>(category));
+          m_arguments[index] = std::move(factor);
+        }
+      }
+
+      std::size_t size() const {
+        return m_arguments.size();
+      }
+
+      template<typename Func>
+      void visit(Func&& func) {
+        for(auto i = std::size_t(0); i < m_arguments.size(); ++i) {
+          func(m_arguments[i], i);
+        }
+      }
+
+      template<typename Func>
+      void visit(Func&& func) const {
+        for(auto i = std::size_t(0); i < m_arguments.size(); ++i) {
+          func(m_arguments[i], i);
+        }
+      }
+      
+    private:
+      std::vector<std::variant<pybind11::object, Factor<pybind11::object>>>
+        m_arguments;
+  };
+}
+
+#endif

--- a/Python/Include/Basis.hpp
+++ b/Python/Include/Basis.hpp
@@ -14,7 +14,6 @@ namespace Rover {
   template<>
   class BasisArguments<PythonSample::Arguments> {
     public:
-
       explicit BasisArguments(const PythonSample::Arguments& args)
           : m_arguments(args.size()) {
         for(auto i = std::size_t(0); i < args.size(); ++i) {

--- a/Python/Include/LinearRegressionModel.hpp
+++ b/Python/Include/LinearRegressionModel.hpp
@@ -5,8 +5,10 @@
 #include "Rover/LinearRegression.hpp"
 #include "Rover/Model.hpp"
 #include "Arithmetics.hpp"
+#include "Basis.hpp"
 #include "Sample.hpp"
 #include "Scalar.hpp"
+#include "VariableTraits.hpp"
 
 namespace Rover {
 

--- a/Python/Include/Model.hpp
+++ b/Python/Include/Model.hpp
@@ -5,7 +5,9 @@
 #include <pybind11/stl.h>
 #include "Rover/Model.hpp"
 #include "Arithmetics.hpp"
+#include "Basis.hpp"
 #include "Scalar.hpp"
+#include "VariableTraits.hpp"
 
 namespace Rover {
 namespace Details {

--- a/Tests/Source/LinearRegressionModelTester.cpp
+++ b/Tests/Source/LinearRegressionModelTester.cpp
@@ -190,3 +190,35 @@ TEST_CASE("test_multivariable_linear_regression_model",
     REQUIRE(model({ 1., 1. }) == Approx(2.));
   }
 }
+
+TEST_CASE("test_categorical_linear_regression_model",
+    "[LinearRegressionModel]") {
+  SECTION("Categorical only.") {
+    using Sample = Rover::Sample<double, std::string>;
+    auto trial = ListTrial<Sample>();
+    trial.insert({ 7., { "A" } });
+    trial.insert({ 5., { "B" } });
+    trial.insert({ 3., { "C" } });
+    trial.insert({ 2., { "A" } });
+    trial.insert({ 9., { "B" } });
+    trial.insert({ 0., { "C" } });
+    auto model = Model<LinearRegression<double>, ListTrial<Sample>>(trial);
+    REQUIRE(model({ "A" }) == Approx(4.5));
+    REQUIRE(model({ "B" }) == Approx(7.));
+    REQUIRE(model({ "C" }) == Approx(1.5));
+  }
+  SECTION("Mixed.") {
+    using Sample = Rover::Sample<double, std::string, double>;
+    auto trial = ListTrial<Sample>();
+    trial.insert({ 7., { "A", 1. } });
+    trial.insert({ 5., { "B", 1. } });
+    trial.insert({ 3., { "C", 1. } });
+    trial.insert({ 8., { "A", 2. } });
+    trial.insert({ 6., { "B", 2. } });
+    trial.insert({ 4., { "C", 2. } });
+    auto model = Model<LinearRegression<double>, ListTrial<Sample>>(trial);
+    REQUIRE(model({ "A", 3. }) == Approx(9.));
+    REQUIRE(model({ "B", 3. }) == Approx(7.));
+    REQUIRE(model({ "C", 3. }) == Approx(5.));
+  }
+}


### PR DESCRIPTION
Had to use the real dummy encoding (without the extra dimension for outliers) because otherwise it is impossible to make the model well-defined during learning. Outliers are handled by setting each dimension equal to `1.0 / num_categories`.
Tests for categorical linear regression are available in `LinearRegressionModelTester.cpp`.