### PR TITLE
Export PythonSelect

### DIFF
--- a/Python/Include/Select.hpp
+++ b/Python/Include/Select.hpp
@@ -1,0 +1,14 @@
+#ifndef ROVER_PYTHON_SELECT_HPP
+#define ROVER_PYTHON_SELECT_HPP
+#include <pybind11/pybind11.h>
+
+namespace Rover {
+
+  //! Exports an instantiation of the Select class.
+  /*!
+    \param module The module to export the class to.
+  */
+  void export_select(pybind11::module& module);
+}
+
+#endif

--- a/Python/Source/Rover.cpp
+++ b/Python/Source/Rover.cpp
@@ -13,6 +13,7 @@
 #include "Range.hpp"
 #include "Sample.hpp"
 #include "ScalarView.hpp"
+#include "Select.hpp"
 #include "TrialView.hpp"
 
 using namespace pybind11;
@@ -32,6 +33,7 @@ PYBIND11_MODULE(rover, module) {
   export_model(module);
   export_pick(module);
   export_random_pick(module);
+  export_select(module);
   export_generate(module);
   export_save_to_csv(module);
   export_load_from_csv(module);

--- a/Python/Source/Select.cpp
+++ b/Python/Source/Select.cpp
@@ -30,7 +30,7 @@ namespace {
       }
 
     private:
-      static Box<object> create_default_selector(object&& size) {
+      static Box<object> create_default_selector(const object& size) {
         auto begin = cast(0);
         auto end = size - 1;
         auto range = Details::PythonRange(std::move(begin), std::move(end),

--- a/Python/Source/Select.cpp
+++ b/Python/Source/Select.cpp
@@ -42,17 +42,17 @@ namespace {
 
       static Container convert_container(Container& container,
           bool keep_dict) {
-        if(is_list(container)) {
-          return std::move(container);
-        } else if(is_set(container)) {
-          return list(container); 
-        } else if(is_dict(container)) {
+        if(is_dict(container)) {
           if(keep_dict) {
             return std::move(container);
           } else {
             auto view = container.attr("values")();
             return list(view);
           }
+        } else if(is_list(container)) {
+          return std::move(container);
+        } else if(is_set(container)) {
+          return list(container); 
         } else {
           throw std::runtime_error(
             "Container does not implement a list, set, or dict.");

--- a/Python/Source/Select.cpp
+++ b/Python/Source/Select.cpp
@@ -1,0 +1,93 @@
+#include "Arithmetics.hpp"
+#include "Autobox.hpp"
+#include "Range.hpp"
+#include "Select.hpp"
+
+using namespace Rover;
+using namespace pybind11;
+
+namespace {
+  class PythonSelect {
+    public:
+      using Container = object;
+      using Selector = object;
+      using Type = object;
+
+      explicit PythonSelect(Container container)
+        : m_container(convert_container(std::move(container), false)),
+          m_selector(create_default_selector(m_container.attr("__len__")())) {}
+
+      PythonSelect(Container container, Selector selector)
+        : m_container(convert_container(std::move(container), true)),
+          m_selector(python_autobox<object>(std::move(selector))) {}
+
+      Type generate(Evaluator& evaluator) {
+        auto index = evaluator.evaluate(m_selector);
+        auto element = m_container.attr("__getitem__")(index);
+        auto generator = python_autobox<object>(element);
+        auto value = evaluator.evaluate(generator);
+        return value;
+      }
+
+    private:
+      static Box<object> create_default_selector(object&& size) {
+        auto begin = cast(0);
+        auto end = size - 1;
+        auto range = Details::PythonRange(std::move(begin), std::move(end),
+          cast(1));
+        auto selector = python_autobox<object>(cast(range,
+          return_value_policy::move));
+        return selector;
+      }
+
+      static Container convert_container(Container& container,
+          bool keep_dict) {
+        if(is_list(container)) {
+          return std::move(container);
+        } else if(is_set(container)) {
+          return list(container); 
+        } else if(is_dict(container)) {
+          if(keep_dict) {
+            return std::move(container);
+          } else {
+            auto view = container.attr("values")();
+            return list(view);
+          }
+        } else {
+          throw std::runtime_error(
+            "Container does not implement a list, set, or dict.");
+        }
+      }
+
+      static bool is_set(const object& obj) {
+        return !hasattr(obj, "__getitem__");
+      }
+
+      static bool is_list(const object& obj) {
+        try {
+          obj.attr("__getitem__")(cast(0));
+        } catch(const pybind11::index_error&) {
+          return true;
+        } catch(const pybind11::error_already_set&) {
+          return false;
+        }
+        return true;
+      }
+
+      static bool is_dict(const object& obj) {
+        return hasattr(obj, "values");
+      }
+
+    private:
+      Container m_container;
+      Box<object> m_selector;
+  };
+}
+
+void Rover::export_select(pybind11::module& module) {
+  class_<PythonSelect>(module, "Select")
+    .def(init<object>())
+    .def(init<object, object>())
+    .def("generate", &PythonSelect::generate);
+  implicitly_convertible<PythonSelect, Box<object>>();
+}


### PR DESCRIPTION
It was possible to use pybind adaptors for Python collections inside C++ select, but it would not work for custom collections Pybind has no exports for. To support those (acting like Python list, set, and dict), I had to implement PythonSelect from scratch.